### PR TITLE
Add commitBody to Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
   ],
   "rangeStrategy": "bump",
   "commitMessagePrefix": "patch:",
+  "commitBody": "Change-type: patch",
   "prHourlyLimit": 0,
   "labels": [
     "dependencies"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add commitBody to Renovate config to try and get Jellyfish version bumps after Renovate PRs are merged.