### PR TITLE
ci: Add auto approve workflow for renovate PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,11 @@
+name: Auto approve
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hmarr/auto-approve-action@v2.0.0
+      if: github.actor == 'renovate[bot]'
+      with:
+        github-token: "${{ secrets.AUTO_APPROVE_TOKEN }}"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Trying out the [Auto Approve GitHub action](https://github.com/marketplace/actions/auto-approve) to automatically approve Renovate dependency bump PRs.