### PR TITLE
ci: Remove dev-major group from Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,16 +20,6 @@
         "patch"
       ],
       "automerge": true
-    },
-    {
-      "groupName": "dev-major",
-      "depTypeList": [
-        "devDependencies"
-      ],
-      "updateTypes": [
-        "major"
-      ],
-      "automerge": true
     }
   ],
   "encrypted": {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Remove `dev-major` dependency group from Renovate config. We don't have enough simultaneous major devDependency bumps to justify keeping this in the config.