### PR TITLE
Remove momentjs dependency

### DIFF
--- a/lib/triggers.js
+++ b/lib/triggers.js
@@ -7,9 +7,9 @@
 const _ = require('lodash')
 const jsone = require('json-e')
 const skhema = require('skhema')
-const moment = require('moment')
-const errors = require('./errors')
 const assert = require('@balena/jellyfish-assert')
+const errors = require('./errors')
+const utils = require('./utils')
 
 const matchesCard = async (context, jellyfish, session, trigger, card) => {
 	if (!card) {
@@ -334,7 +334,7 @@ exports.getNextExecutionDate = (trigger, lastExecutionDate) => {
 	}
 
 	// The interval should be an ISO 8601 duration string, like PT1H
-	const duration = moment.duration(trigger.data.interval).asMilliseconds()
+	const duration = utils.durationToMs(trigger.data.interval)
 	assert.INTERNAL(null, duration !== 0,
 		errors.WorkerInvalidDuration,
 		`Invalid interval: ${trigger.data.interval}`)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@
  * Proprietary and confidential.
  */
 
+const iso8601Duration = require('iso8601-duration')
 const uuid = require('@balena/jellyfish-uuid')
 
 /**
@@ -100,4 +101,16 @@ exports.hasCard = async (context, jellyfish, session, object) => {
 exports.getEventSlug = async (type) => {
 	const id = await uuid.random()
 	return `${type}-${id}`
+}
+
+/**
+ * @summary Convert an ISO 8601 duration to milliseconds
+ * @param {String} duration - the ISO 8601 duration (e.g. 'PT1H')
+ * @returns {String} - the duration in milliseconds
+ */
+exports.durationToMs = (duration) => {
+	if (!duration) {
+		return 0
+	}
+	return iso8601Duration.toSeconds(iso8601Duration.parse(duration)) * 1000
 }

--- a/lib/utils.spec.js
+++ b/lib/utils.spec.js
@@ -7,6 +7,12 @@
 const ava = require('ava')
 const utils = require('./utils')
 
+ava('durationToMs converts a duration to milliseconds', (test) => {
+	const duration = 'PT1H'
+	const durationMs = utils.durationToMs(duration)
+	test.is(durationMs, 3600000)
+})
+
 ava('.getActionArgumentsSchema() should return a wildcard schema if no args', (test) => {
 	const schema = utils.getActionArgumentsSchema({
 		data: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3387,6 +3387,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "iso8601-duration": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/iso8601-duration/-/iso8601-duration-1.2.0.tgz",
+      "integrity": "sha512-ErTBd++b17E8nmWII1K1uZtBgD1E8RjyvwmxlCjPHNqHMD7gmcMHOw0E8Ro/6+QT4PhHRSnnMo7bxa1vFPkwhg=="
+    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -4102,11 +4107,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.4.tgz",
       "integrity": "sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw==",
       "dev": true
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "bluebird": "^3.7.2",
     "errio": "^1.2.2",
     "fast-equals": "^2.0.0",
+    "iso8601-duration": "^1.2.0",
     "json-e": "^4.3.0",
     "lodash": "^4.17.20",
-    "moment": "^2.29.1",
     "skhema": "^5.3.3",
     "typed-errors": "^1.1.0"
   },


### PR DESCRIPTION
Note - date-fns does not support parsing ISO 8601 durations so we use a small dedicated dependency to do this for us.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to: https://github.com/product-os/jellyfish/issues/5130