### PR TITLE
fix: durationToMs should return 0 if duration is invalid

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -106,11 +106,12 @@ exports.getEventSlug = async (type) => {
 /**
  * @summary Convert an ISO 8601 duration to milliseconds
  * @param {String} duration - the ISO 8601 duration (e.g. 'PT1H')
- * @returns {String} - the duration in milliseconds
+ * @returns {String} - the duration in milliseconds, or 0 if the duration is invalid
  */
 exports.durationToMs = (duration) => {
-	if (!duration) {
+	try {
+		return iso8601Duration.toSeconds(iso8601Duration.parse(duration)) * 1000
+	} catch (err) {
 		return 0
 	}
-	return iso8601Duration.toSeconds(iso8601Duration.parse(duration)) * 1000
 }

--- a/lib/utils.spec.js
+++ b/lib/utils.spec.js
@@ -13,6 +13,12 @@ ava('durationToMs converts a duration to milliseconds', (test) => {
 	test.is(durationMs, 3600000)
 })
 
+ava('durationToMs returns 0 if duration is invalid', (test) => {
+	const duration = 'BLAH'
+	const durationMs = utils.durationToMs(duration)
+	test.is(durationMs, 0)
+})
+
 ava('.getActionArgumentsSchema() should return a wildcard schema if no args', (test) => {
 	const schema = utils.getActionArgumentsSchema({
 		data: {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>