### PR TITLE
Evaluate all $$formula fields when patching

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -444,7 +444,8 @@ exports.patchCard = async (context, jellyfish, session, typeCard, options, objec
 	options.eventType = 'update'
 
 	return commit(context, jellyfish, session, typeCard, object, options, async () => {
-		const newPatch = jellyscript.evaluatePatch(typeCard.data.schema, object, patch)
+		const card = await jellyfish.getCardById(context, session, object.id)
+		const newPatch = jellyscript.evaluatePatch(typeCard.data.schema, card, patch)
 		return jellyfish.patchCardBySlug(
 			context, session, `${object.slug}@${object.version}`, newPatch, {
 				type: typeCard.slug

--- a/lib/tests/executor.spec.js
+++ b/lib/tests/executor.spec.js
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const sinon = require('sinon')
+const jsonpatch = require('fast-json-patch')
+const _ = require('lodash')
+const uuid = require('@balena/jellyfish-uuid')
+const executor = require('../executor')
+const user = require('./fixtures/user.json')
+const user1 = require('./fixtures/user1.json')
+
+const privilegedSession = {}
+
+const getContext = async () => {
+	const id = await uuid.random()
+	return {
+		id,
+		privilegedSession
+	}
+}
+
+const session = {}
+
+const sandbox = sinon.createSandbox()
+
+ava.beforeEach(async (test) => {
+	const oldUser = _.merge({}, user1, {
+		data: {
+			email: 'old@balena.io'
+		}
+	})
+	const context = await getContext()
+	test.context = {
+		...test.context,
+		oldUser,
+		context,
+		jellyfish: {
+			getCardById: sandbox.stub().resolves(oldUser),
+			getCardBySlug: sandbox.stub().resolves(oldUser)
+		},
+		commonOptions: {}
+	}
+})
+
+ava.afterEach(() => {
+	sandbox.restore()
+})
+
+ava('insertCard updates $$formula fields before inserting', async (test) => {
+	const {
+		context,
+		jellyfish,
+		commonOptions
+	} = test.context
+	const options = {
+		...commonOptions,
+		attachEvents: false
+	}
+	const expectedInsertedCard = _.merge({}, user1, {
+		data: {
+			profile: {
+				name: {
+					fullName: 'John Doe',
+					initials: 'JD'
+				}
+			}
+		}
+	})
+	jellyfish.insertCard = (ctx, sess, res) => {
+		return res
+	}
+
+	const insertedCard = await executor.insertCard(context, jellyfish, session, user, options, user1)
+	test.deepEqual(insertedCard, expectedInsertedCard)
+})
+
+ava('replaceCard updates $$formula fields before replacing', async (test) => {
+	const {
+		context,
+		jellyfish,
+		commonOptions
+	} = test.context
+	const options = {
+		...commonOptions,
+		attachEvents: false
+	}
+	const expectedReplacedCard = _.merge({}, user1, {
+		data: {
+			profile: {
+				name: {
+					fullName: 'John Doe',
+					initials: 'JD'
+				}
+			}
+		}
+	})
+	jellyfish.replaceCard = (ctx, sess, res) => {
+		return res
+	}
+
+	const replacedCard = await executor.replaceCard(context, jellyfish, session, user, options, user1)
+	test.deepEqual(replacedCard, expectedReplacedCard)
+})
+
+ava('patchCard updates $$formula fields before patching', async (test) => {
+	const {
+		context,
+		jellyfish,
+		commonOptions
+	} = test.context
+	const patchOptions = {
+		...commonOptions,
+		attachEvents: false
+	}
+	jellyfish.getCardBySlug = sandbox.stub().resolves(user1)
+	const userPatch = [
+		{
+			op: 'replace',
+			path: '/data/profile/name/first',
+			value: 'Bob'
+		}
+	]
+	const expectedPatchedCard = _.merge({}, user1, {
+		data: {
+			profile: {
+				name: {
+					first: 'Bob',
+					fullName: 'Bob Doe',
+					initials: 'BD'
+				}
+			}
+		}
+	})
+	jellyfish.patchCardBySlug = (ctx, sess, version, patch, options) => {
+		return jsonpatch.applyPatch(user1, patch, false, false).newDocument
+	}
+
+	const patchedCard = await executor.patchCard(context, jellyfish, session, user, patchOptions, user1, userPatch)
+	test.deepEqual(patchedCard, expectedPatchedCard)
+})

--- a/lib/tests/fixtures/user.json
+++ b/lib/tests/fixtures/user.json
@@ -1,0 +1,67 @@
+{
+  "id": "3cccf88e-34a0-4b80-b715-ea531335f0da",
+  "data": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "slug",
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "profile": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "object",
+                  "properties": {
+                    "fullName": {
+                      "type": "string",
+                      "$$formula": "CONCATENATE(this.data.profile.name.first, ' ', this.data.profile.name.last)"
+                    },
+                    "initials": {
+                      "type": "string",
+                      "$$formula": "CONCATENATE(LEFT(this.data.profile.name.first, 1), LEFT(this.data.profile.name.last, 1))"
+                    },
+                    "last": {
+                      "type": "string",
+                      "title": "Last name"
+                    },
+                    "first": {
+                      "type": "string",
+                      "title": "First name"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "slug": {
+          "type": "string",
+          "pattern": "^user-[a-z0-9-]+$"
+        },
+        "markers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-_/:+]+$"
+          }
+        }
+      }
+    }
+  },
+  "name": "Jellyfish User",
+  "slug": "user",
+  "tags": [],
+  "type": "type@1.0.0",
+  "links": {},
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "linked_at": {},
+  "capabilities": []
+}

--- a/lib/tests/fixtures/user1.json
+++ b/lib/tests/fixtures/user1.json
@@ -1,0 +1,21 @@
+{
+  "id": "93d7ff1b-4aaa-4951-9c60-af5721c06ff2",
+  "data": {
+    "profile": {
+      "name": {
+        "first": "John",
+        "last": "Doe"
+      }
+    }
+  },
+  "slug": "user-johndoe-0da17b1d-5704-4a97-b190-d50845a5d10c",
+  "tags": [],
+  "type": "user@1.0.0",
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "created_at": "2020-11-10T04:54:06.260Z",
+  "updated_at": "2020-11-10T04:54:07.011Z",
+  "capabilities": []
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,16 +212,27 @@
       }
     },
     "@balena/jellyfish-jellyscript": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-jellyscript/-/jellyfish-jellyscript-1.0.42.tgz",
-      "integrity": "sha512-X1BvcGy7n64vRgHnfrfvlcKBbpsDR2fAY9bFxAzV2t2Zjgl7vSqnk/eVRNumEGslqlGrPvHC6VF5Pn/DrEzHIg==",
+      "version": "2.0.0-evaluate-all-fields-when-patching-d7342824e62b7720c68a719fb2147a04f9df7f26",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-jellyscript/-/jellyfish-jellyscript-2.0.0-evaluate-all-fields-when-patching-d7342824e62b7720c68a719fb2147a04f9df7f26.tgz",
+      "integrity": "sha512-hIIu2eCNVSd07NGm3BA3vVLMj+K37hv46I+p6sLrr2sQSveiCPGOVw5eYb1waX5YJTjuMsJELPDdYibSG5uCPQ==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.29",
         "@formulajs/formulajs": "^2.6.1",
         "esprima": "^4.0.1",
+        "fast-json-patch": "^3.0.0-1",
         "lodash": "^4.17.20",
         "object-hash": "^2.0.3",
         "static-eval": "^2.1.0"
+      },
+      "dependencies": {
+        "@balena/jellyfish-assert": {
+          "version": "1.0.29",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.0.29.tgz",
+          "integrity": "sha512-aw1poKfGNnnNywkqClMIy+53eNpU03KHtrGGTX60D4AoTSxHeg1g1pPAYq6/KsUHuu2mkRaZD2L8SbmRisDUdQ==",
+          "requires": {
+            "lodash": "^4.17.20"
+          }
+        }
       }
     },
     "@balena/jellyfish-logger": {
@@ -420,6 +431,51 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.2.0.tgz",
+      "integrity": "sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
     "@szmarczak/http-timer": {
@@ -1800,6 +1856,12 @@
       "integrity": "sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ=",
       "dev": true
     },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2506,6 +2568,11 @@
         "micromatch": "^4.0.2",
         "picomatch": "^2.2.1"
       }
+    },
+    "fast-json-patch": {
+      "version": "3.0.0-1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+      "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3626,6 +3693,12 @@
       "resolved": "https://registry.npmjs.org/jstat/-/jstat-1.9.4.tgz",
       "integrity": "sha512-IiTPlI7pcrsq41EpDzrghlA1fhiC9GXxNqO4k5ogsjsM1XAWQ8zESH/bZsExLVgQsYpXE+7c11kEbbuxTLUpJQ=="
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -3849,6 +3922,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.omit": {
@@ -4149,6 +4228,19 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -4517,6 +4609,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -5205,6 +5314,21 @@
         }
       }
     },
+    "sinon": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.1.tgz",
+      "integrity": "sha512-naPfsamB5KEE1aiioaoqJ6MEhdUs/2vtI5w1hPAXX/UwvoPjXcwh1m5HiKx0HGgKR8lQSoFIgY5jM6KK8VrS9w==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.2.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      }
+    },
     "skhema": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.3.3.tgz",
@@ -5755,6 +5879,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@balena/jellyfish-assert": "^1.0.29",
-    "@balena/jellyfish-jellyscript": "^1.0.42",
+    "@balena/jellyfish-jellyscript": "2.0.0-evaluate-all-fields-when-patching-d7342824e62b7720c68a719fb2147a04f9df7f26",
     "@balena/jellyfish-logger": "^0.0.146",
     "@balena/jellyfish-uuid": "^1.0.31",
     "bluebird": "^3.7.2",
@@ -54,9 +54,11 @@
     "eslint-plugin-lodash": "^7.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
+    "fast-json-patch": "^3.0.0-1",
     "husky": "^4.3.0",
     "jsdoc-to-markdown": "^6.0.1",
-    "lint-staged": "^10.5.1"
+    "lint-staged": "^10.5.1",
+    "sinon": "^9.2.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
All $$formula fields are now evaluated when patching a card. Unit tests have been added (more needed) to test some of these scenarios.

Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This is a part of **STEP 5** of the [work on improving $$formula handling](https://docs.google.com/drawings/d/1px_BSh--CG3E-b9Cp8UvN9QVFoVI5FLFzUZVmbkIaoE/edit?usp=sharing).