### PR TITLE
Pass the sync instance to the action context

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -200,6 +200,7 @@ exports.Worker = class Worker {
 		return {
 			errors,
 			defaults: this.jellyfish.defaults,
+			sync: context.sync,
 			getEventSlug: utils.getEventSlug,
 			getCardById: _.bind(function (lsession, id) {
 				return this.jellyfish.getCardById(context, lsession, id)


### PR DESCRIPTION
This can then be used by the action handlers. 

Note - this is safe to commit as-is without sync actually being populated.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>