### PR TITLE
Action cards are now loaded by the card-loader

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,13 +175,8 @@ exports.Worker = class Worker {
 		this.id = await uuid.random()
 		this.sync = context.sync
 
-		// Insert worker specific cards first
+		// Insert worker specific cards
 		await Bluebird.map(Object.values(CARDS), async (card) => {
-			return this.jellyfish.replaceCard(context, this.session, card)
-		})
-
-		// Then load up the library
-		await Bluebird.map(_.map(_.values(this.library), 'card'), async (card) => {
 			return this.jellyfish.replaceCard(context, this.session, card)
 		})
 	}


### PR DESCRIPTION
Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Because the actions cards will be defined in plugins and loaded along with any other plugin cards, the code in jellyfish-worker that does an upsert on the action cards can just be removed.

Depends on:
* https://github.com/product-os/jellyfish-plugin-base/pull/5