### PR TITLE
Change tick log loglevel to debug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -756,7 +756,7 @@ exports.Worker = class Worker {
 	async tick (context, session, options) {
 		const currentTriggers = this.getTriggers()
 
-		logger.info(context, 'Processing tick request', {
+		logger.debug(context, 'Processing tick request', {
 			triggers: currentTriggers.length
 		})
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

This log is by far the noisiest of all of our logs and provides little value. Could be useful for debugging, but probably doesn't need to be at `info` level.