### PR TITLE
Improve performance of trigger contract matching

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -56,6 +56,21 @@ const getInputCard = async (context, jellyfish, session, identifier) => {
 	return jellyfish.getCardById(context, session, identifier)
 }
 
+/**
+ * @summary A pipeline function that runs standard logic for all contract
+ * operations ran through the worker
+ * @function
+ * @private
+ *
+ * @param {Object} context - execution context
+ * @param {Object} jellyfish - jellyfish kernel instance
+ * @param {String} session - session id
+ * @param {Object} typeCard - The full type contract for the card being
+ * inserted or updated
+ * @param {Object} current - The full contract prior to being updated, if it exists
+ * @param {Object} options - Options object
+ * @param {Function} fn - an asynchronous function that will perform the operation
+ */
 const commit = async (context, jellyfish, session, typeCard, current, options, fn) => {
 	assert.INTERNAL(context,
 		typeCard && typeCard.data && typeCard.data.schema,
@@ -116,8 +131,17 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 				const creatorSession = await utils.getActorKey(
 					context, jellyfish, session, createCard.data.actor)
 
+				/*
+				 * Retrieve the card using the subscription creators permissions and
+				 * check if it matches the view schema
+				 */
 				const filteredCard = await triggers.matchesCard(
-					context, jellyfish, creatorSession.id, view.data.allOf[0].schema, insertedCard)
+					context,
+					jellyfish,
+					creatorSession.id,
+					view.data.allOf[0].schema,
+					await jellyfish.getCardById(context, creatorSession.id, insertedCard.id)
+				)
 
 				if (!filteredCard) {
 					return

--- a/lib/triggers.js
+++ b/lib/triggers.js
@@ -16,17 +16,8 @@ exports.matchesCard = async (context, jellyfish, session, filter, card) => {
 		return false
 	}
 
-	/*
-	 * Filter card by user's permissions
-	 */
-	const filteredCard = await jellyfish.getCardById(context, session, card.id)
-
-	if (!filteredCard) {
-		return false
-	}
-
-	const isValid = skhema.isValid(filter, filteredCard)
-	const isLink = filteredCard.type.split('@')[0] === 'link'
+	const isValid = skhema.isValid(filter, card)
+	const isLink = card.type.split('@')[0] === 'link'
 
 	/*
 	 * We don't discard triggers that didn't match the card
@@ -48,7 +39,7 @@ exports.matchesCard = async (context, jellyfish, session, filter, card) => {
 	 * against the card or not.
 	 */
 	if (!filter || !filter.$$links) {
-		return isValid ? filteredCard : false
+		return isValid ? card : false
 	}
 
 	/*
@@ -90,17 +81,17 @@ exports.matchesCard = async (context, jellyfish, session, filter, card) => {
 	 */
 	if (isLink) {
 		const linkType = Object.keys(schema.$$links)[0]
-		if (linkType === filteredCard.name) {
-			schema.properties.id.const = filteredCard.data.from.id
-		} else if (linkType === filteredCard.data.inverseName) {
-			schema.properties.id.const = filteredCard.data.to.id
+		if (linkType === card.name) {
+			schema.properties.id.const = card.data.from.id
+		} else if (linkType === card.data.inverseName) {
+			schema.properties.id.const = card.data.to.id
 
 		// Abort if the link doesn't match.
 		} else {
 			return false
 		}
 	} else {
-		schema.properties.id.const = filteredCard.id
+		schema.properties.id.const = card.id
 	}
 
 	// Run the query


### PR DESCRIPTION
With this change, we only load the inserted contract using the user's
session when evaluating subscriptions, as it is redundant to
make this request when evaluating triggered actions (the contract is
already restricted by the session permissions in that code path)

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>