### PR TITLE
support transformers within contract-repositories

### DIFF
--- a/lib/transformers.js
+++ b/lib/transformers.js
@@ -39,7 +39,14 @@ exports.evaluate = ({
 			if (match) {
 				// The transformer should be run on behalf of the actor that owns the
 				// transformer
-				const [ transformerActor ] = await query({
+				console.log('searching for direct owner of transformer')
+				const [ transformerOwner ] = await query({
+					type: 'object',
+					properties: {
+						active: {
+							const: true
+						}
+					},
 					$$links: {
 						owns: {
 							type: 'object',
@@ -49,11 +56,51 @@ exports.evaluate = ({
 								}
 							}
 						}
-					},
-					type: 'object'
+					}
 				}, {
 					limit: 1
 				})
+
+				let transformerActor = transformerOwner
+
+				// Or by the actor that owns its contract-repository
+				if (!transformerActor) {
+					console.log('searching for contract repo as owner')
+					const [ repoOwner ] = await query({
+						type: 'object',
+						properties: {
+							active: {
+								const: true
+							}
+						},
+						$$links: {
+							owns: {
+								type: 'object',
+								required: [ 'type', 'data' ],
+								properties: {
+									type: {
+										const: 'contract-repository@1.0.0'
+									},
+									active: {
+										const: true
+									},
+									data: {
+										type: 'object',
+										required: [ 'base_slug' ],
+										properties: {
+											base_slug: {
+												const: transformer.slug
+											}
+										}
+									}
+								}
+							}
+						}
+					}, {
+						limit: 1
+					})
+					transformerActor = repoOwner
+				}
 
 				if (transformerActor) {
 					const actionRequest = {


### PR DESCRIPTION
If a transformer has no owner but is contained within a `contract-repository` which is owned, we use this contract as an actor for running transformers.

Relates to https://github.com/product-os/jellyfish-plugin-product-os/pull/92