### PR TITLE
Allow the trigger `mode` field to be undefined

### DIFF
--- a/lib/executor.ts
+++ b/lib/executor.ts
@@ -232,9 +232,6 @@ const commit = async (
 					return;
 				}
 
-				console.log(creatorSession);
-				console.log(insertedCard);
-
 				const targetContract = await jellyfish.getCardById(
 					context,
 					creatorSession.id,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -181,7 +181,6 @@ const parseTrigger = (
 		arguments: trigger.arguments,
 		schedule: trigger.schedule,
 		filter: {},
-		mode: 'update',
 	};
 
 	// TODO: "startDate" is not on the triggered-action type definition.

--- a/lib/triggers.ts
+++ b/lib/triggers.ts
@@ -224,11 +224,12 @@ export const getRequest = async (
 	jellyfish: JellyfishKernel,
 	trigger: {
 		filter: any;
-		mode: any;
+		mode?: any;
 		arguments: any;
 		target: any;
 		action: any;
 		id: any;
+		slug?: any;
 	},
 	// If getRequest is called by a time triggered action, then card will be null
 	card: core.Contract | null,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,7 +17,7 @@ export interface WorkerTriggerObjectInput {
 	arguments: worker.TriggeredActionData2['arguments'];
 	interval?: worker.TriggeredActionData2['interval'];
 	filter: worker.TriggeredActionData2['filter'];
-	mode: worker.TriggeredActionData2['mode'];
+	mode?: worker.TriggeredActionData2['mode'];
 	schedule: worker.TriggeredActionData2['schedule'];
 }
 
@@ -33,7 +33,7 @@ export interface ParsedWorkerTriggerObject {
 	startDate?: any;
 	filter: worker.TriggeredActionData2['filter'];
 	interval?: worker.TriggeredActionData2['interval'];
-	mode: worker.TriggeredActionData2['mode'];
+	mode?: worker.TriggeredActionData2['mode'];
 }
 
 // tslint:disable: jsdoc-format


### PR DESCRIPTION
The typescript conversion changed the mode to default to `update`, which
caused some triggered actions to no longer run.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>