### PR TITLE
Fix bug where trigger "mode" always defaults to "update"

### DIFF
--- a/lib/executor.ts
+++ b/lib/executor.ts
@@ -645,7 +645,6 @@ const commit = async (
 					filter: trigger.data.filter,
 					arguments: trigger.data.arguments,
 					schedule: 'async',
-					mode: 'update',
 				};
 
 				if (trigger.data.mode) {


### PR DESCRIPTION
This bug prevents mode agnostic triggered actions from running

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>