### PR TITLE
Begin migrating integration tests from main app

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,46 @@
 {
   "extends": [
-    "github>product-os/jellyfish-renovate-config"
-  ]
+    "config:base"
+  ],
+  "enabledManagers": [
+    "npm"
+  ],
+  "force": {
+    "constraints": {
+      "node": "< 15.0.0"
+    }
+  },
+  "pruneStaleBranches": false,
+  "rangeStrategy": "bump",
+  "commitMessagePrefix": "patch:",
+  "commitBody": "Change-type: patch",
+  "prHourlyLimit": 0,
+  "labels": [
+    "dependencies"
+  ],
+  "ignoreDeps": [
+    "node"
+  ],
+  "packageRules": [
+    {
+      "groupName": "non-major",
+      "updateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "packagePatterns": ["@balena/jellyfish-*"],
+      "updateTypes": [
+        "minor",
+        "patch"
+      ],
+      "enabled": false
+    }
+  ],
+  "encrypted": {
+    "npmToken": "vDPwvJKwTov0qGsio60oGYnAgYYDgUgSLu3Ttm2sDa3JmOn7y6yjcvuO2+iFFuE9QO9lBa1L9sKN+Bl+tZXo+U9I2osJc+eoNfAJPzqUO1VIdnRne7q5StFI8GGfdq7+sL7O4hyIAXPKH4zn+KVJKbwfKMsys8K+ccjvKnCwl59ef00BZpFnAOBrUPdPSPWlYrEOhBFQlurPfsRRWUFGC/1aHCCvleTX1uIsOXiu1r6u6WQ9/d89DLiY9+3NM07Q34HFD7QY71PI/QAzjYDx22vVq0vbDG1FJg9IgzFudkGzF4kK3FWl30KPon8sO0YeDomYaTxQTKAWgfkn5NcLzg=="
+  }
 }

--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,3 +1,5 @@
+docker:
+  publish: false
 npm:
   platforms:
     - name: linux

--- a/@types/errio.d.ts
+++ b/@types/errio.d.ts
@@ -14,4 +14,6 @@ declare module 'errio' {
 			stack: boolean;
 		},
 	) => object;
+
+	let fromObject: (data: any) => Error;
 }

--- a/@types/jellyfish-core.d.ts
+++ b/@types/jellyfish-core.d.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+declare module '@balena/jellyfish-core/lib/cards/mixins' {
+	const mixins: any;
+	export default mixins;
+}
+
+// TS-TODO: These additional tpyes are required because of the abominated subpath imports used in `backend-helpers.ts`
+// This needs to be cleaned up.
+declare module '@balena/jellyfish-core' {
+	import { core } from '@balena/jellyfish-types';
+
+	export class Backend extends core.Backend {
+		constructor(arg1: any, arg2: any, arg3: any): core.Backend;
+		connect: core.Backend['connect'];
+		cache: core.Backend['cache'];
+		errors: core.Backend['errors'];
+		connection: core.Backend['connection'];
+		disconnect: core.Backend['disconnect'];
+		drop: core.Backend['drop'];
+		reset: core.Backend['reset'];
+		insertElement: core.Backend['insertElement'];
+		upsertElement: core.Backend['upsertElement'];
+		withTransaction: core.Backend['withTransaction'];
+		withSerializableTransaction: core.Backend['withSerializableTransaction'];
+		getElementById: core.Backend['getElementById'];
+		getElementBySlug: core.Backend['getElementBySlug'];
+		getElementsById: core.Backend['getElementsById'];
+		query: core.Backend['query'];
+		prepareQueryForStream: core.Backend['prepareQueryForStream'];
+		stream: core.Backend['stream'];
+		getStatus: core.Backend['getStatus'];
+		createTypeIndex: core.Backend['createTypeIndex'];
+		createFullTextSearchIndex: core.Backend['createFullTextSearchIndex'];
+	}
+
+	export class MemoryCache implements core.Cache {
+		constructor(arg: any): core.Cache;
+		connect: () => Promise<void>;
+		disconnect: () => Promise<void>;
+		set: <TElement>(table: string, element: TElement) => Promise<void>;
+		unset: <TElement>(element: TElement) => Promise<void>;
+		reset: () => Promise<void>;
+		getById: <TElement>(
+			table: string,
+			id: string,
+		) => Promise<CacheResult<TElement>>;
+		getBySlug: <TElement>(
+			table: string,
+			slug: string,
+		) => Promise<CacheResult<TElement>>;
+		setMissingId: (table: string, id: string) => Promise<void>;
+		setMissingSlug: (table: string, slug: string) => Promise<void>;
+	}
+
+	export class Kernel extends core.JellyfishKernel {
+		constructor(arg: any): core.JellyfishKernel;
+		initialize: core.JellyfishKernel['initialize'];
+		backend: core.JellyfishKernel['backend'];
+		errors: core.JellyfishKernel['errors'];
+		cards: core.JellyfishKernel['cards'];
+		sessions: core.JellyfishKernel['sessions'];
+		disconnect: core.JellyfishKernel['disconnect'];
+		getCardById: core.JellyfishKernel['getCardById'];
+		getCardBySlug: core.JellyfishKernel['getCardBySlug'];
+		insertCard: core.JellyfishKernel['insertCard'];
+		replaceCard: core.JellyfishKernel['replaceCard'];
+		patchCardBySlug: core.JellyfishKernel['patchCardBySlug'];
+		query: core.JellyfishKernel['query'];
+		stream: core.JellyfishKernel['stream'];
+		defaults: core.JellyfishKernel['defaults'];
+		getStatus: core.JellyfishKernel['getStatus'];
+	}
+
+	export const errors: any;
+}

--- a/@types/jellyfish-plugin-default.d.ts
+++ b/@types/jellyfish-plugin-default.d.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+declare module '@balena/jellyfish-plugin-default' {
+	interface PluginInterface {
+		loadCards: (arg: any) => any;
+	}
+
+	const Plugin: PluginInterface;
+	export = Plugin;
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM balena/open-balena-base:11.0.2
+
+WORKDIR /usr/src/jellyfish
+ARG NPM_TOKEN
+
+# Install npm packages
+COPY package.json package-lock.json ./
+RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc && \
+	npm ci && rm -f ~/.npmrc
+
+# Copy in source and run lint and unit tests
+COPY . ./
+RUN npm run test

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,16 @@
+###########################################################
+# Runtime
+###########################################################
+
+FROM resinci/jellyfish-test:1.3.29
+
+WORKDIR /usr/src/jellyfish
+
+COPY package.json package-lock.json /usr/src/jellyfish/
+ARG NPM_TOKEN
+RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc && \
+    npm ci && rm -f ~/.npmrc
+
+# Copy in source code and config, and run integration tests
+COPY . ./
+CMD /bin/bash -c "make test-integration"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,139 @@
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # -----------------------------------------------
+# Test Runtime Configuration
+# -----------------------------------------------
+
+# Project name
+NAME ?= jellyfish
+
+DATABASE ?= postgres
+export DATABASE
+
+# The default postgres user is your local user
+POSTGRES_USER ?= $(shell whoami)
+export POSTGRES_USER
+POSTGRES_PASSWORD ?=
+export POSTGRES_PASSWORD
+POSTGRES_PORT ?= 5432
+export POSTGRES_PORT
+POSTGRES_HOST ?= localhost
+export POSTGRES_HOST
+POSTGRES_DATABASE ?= jellyfish
+export POSTGRES_DATABASE
+
+# silence graphile-worker logs
+NO_LOG_SUCCESS = 1
+export NO_LOG_SUCCESS
+
+PORT ?= 8000
+export PORT
+LOGLEVEL ?= info
+export LOGLEVEL
+DB_HOST ?= localhost
+export DB_HOST
+DB_PORT ?= 28015
+export DB_PORT
+DB_USER ?=
+export DB_USER
+DB_PASSWORD ?=
+export DB_PASSWORD
+SERVER_HOST ?= http://localhost
+export SERVER_HOST
+SERVER_PORT ?= $(PORT)
+export SERVER_PORT
+METRICS_PORT ?= 9000
+export METRICS_PORT
+SOCKET_METRICS_PORT ?= 9001
+export SOCKET_METRICS_PORT
+SERVER_DATABASE ?= jellyfish
+export SERVER_DATABASE
+UI_PORT ?= 9000
+export UI_PORT
+UI_HOST ?= $(SERVER_HOST)
+export UI_HOST
+LIVECHAT_HOST ?= $(SERVER_HOST)
+export LIVECHAT_HOST
+LIVECHAT_PORT ?= 9100
+export LIVECHAT_PORT
+DB_CERT ?=
+export DB_CERT
+LOGENTRIES_TOKEN ?=
+export LOGENTRIES_TOKEN
+SENTRY_DSN_SERVER ?=
+export SENTRY_DSN_SERVER
+NODE_ENV ?= test
+export NODE_ENV
+REDIS_NAMESPACE ?= $(SERVER_DATABASE)
+export REDIS_NAMESPACE
+REDIS_PASSWORD ?=
+export REDIS_PASSWORD
+REDIS_PORT ?= 6379
+export REDIS_PORT
+REDIS_HOST ?= localhost
+export REDIS_HOST
+POD_NAME ?= localhost
+export POD_NAME
+OAUTH_REDIRECT_BASE_URL ?= $(SERVER_HOST):$(UI_PORT)
+export OAUTH_REDIRECT_BASE_URL
+MONITOR_SECRET_TOKEN ?= TEST
+export MONITOR_SECRET_TOKEN
+RESET_PASSWORD_SECRET_TOKEN ?=
+export RESET_PASSWORD_SECRET_TOKEN
+
+FS_DRIVER ?= localFS
+export FS_DRIVER
+AWS_ACCESS_KEY_ID ?=
+export AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY ?=
+export AWS_SECRET_ACCESS_KEY
+AWS_S3_BUCKET_NAME ?=
+export AWS_S3_BUCKET_NAME
+INTEGRATION_DEFAULT_USER ?= admin
+export INTEGRATION_DEFAULT_USER
+
+# Automatically created user
+# when not running in production
+TEST_USER_USERNAME ?= jellyfish
+export TEST_USER_USERNAME
+TEST_USER_PASSWORD ?= jellyfish
+export TEST_USER_PASSWORD
+TEST_USER_ROLE ?= user-test
+export TEST_USER_ROLE
+TEST_USER_ORGANIZATION ?= balena
+export TEST_USER_ORGANIZATION
+
+MAIL_TYPE ?= mailgun
+export MAIL_TYPE
+MAILGUN_TOKEN ?=
+export MAILGUN_TOKEN
+MAILGUN_DOMAIN ?= mail.ly.fish
+export MAILGUN_DOMAIN
+MAILGUN_BASE_URL = https://api.mailgun.net/v3
+export MAILGUN_BASE_URL
+
+# GitHub
+INTEGRATION_GITHUB_APP_ID ?=
+export INTEGRATION_GITHUB_APP_ID
+
+# The base64 encoded PEM key
+INTEGRATION_GITHUB_PRIVATE_KEY ?=
+export INTEGRATION_GITHUB_PRIVATE_KEY
+
+TEST_INTEGRATION_GITHUB_REPO ?= product-os/jellyfish-test-github
+export TEST_INTEGRATION_GITHUB_REPO
+TEST_INTEGRATION_FRONT_INBOX_1 ?= inb_qf8q # Jellyfish Testfront
+export TEST_INTEGRATION_FRONT_INBOX_1
+TEST_INTEGRATION_FRONT_INBOX_2 ?= inb_8t8y # Jellyfish Test Inbox
+export TEST_INTEGRATION_FRONT_INBOX_2
+TEST_INTEGRATION_DISCOURSE_CATEGORY ?= 44 # sandbox
+export TEST_INTEGRATION_DISCOURSE_CATEGORY
+TEST_INTEGRATION_DISCOURSE_USERNAME ?= jellyfish
+export TEST_INTEGRATION_DISCOURSE_USERNAME
+TEST_INTEGRATION_DISCOURSE_NON_MODERATOR_USERNAME ?= jellyfish-test
+export TEST_INTEGRATION_DISCOURSE_NON_MODERATOR_USERNAME
+
+# -----------------------------------------------
 # Build Configuration
 # -----------------------------------------------
 
@@ -28,7 +161,7 @@ ifdef MATCH
 AVA_ARGS += --match $(MATCH)
 endif
 
-FILES ?= "'./lib/**/*.spec.js'"
+FILES ?= "'./{lib,test}/**/*.spec.js'"
 export FILES
 
 # -----------------------------------------------
@@ -42,4 +175,7 @@ lint:
 	npx depcheck --ignore-bin-package
 
 test:
-	node $(NODE_DEBUG_ARGS) ./node_modules/.bin/ava -v $(AVA_ARGS) $(FILES)
+	node $(NODE_DEBUG_ARGS) ./node_modules/.bin/jest $(FILES) 
+
+test-integration:
+	FILES="./test/integration/**/*.spec.ts" make test

--- a/README.md
+++ b/README.md
@@ -11,13 +11,18 @@ framework.
 Below is an example how to use this library:
 
 ```js
-const Worker = require('@balena/jellyfish-worker')
+const Worker = require('@balena/jellyfish-worker');
 
-const worker = new Worker(jellyfish, jellyfish.sessions.admin, actionLibrary, consumer)
-await worker.initialize(context)
+const worker = new Worker(
+	jellyfish,
+	jellyfish.sessions.admin,
+	actionLibrary,
+	consumer,
+);
+await worker.initialize(context);
 
-const id = worker.getId()
-console.log(`Worker ID: ${worker.getId()}`)
+const id = worker.getId();
+console.log(`Worker ID: ${worker.getId()}`);
 ```
 
 # Documentation
@@ -25,3 +30,17 @@ console.log(`Worker ID: ${worker.getId()}`)
 [![Publish Documentation](https://github.com/product-os/jellyfish-worker/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/product-os/jellyfish-worker/actions/workflows/publish-docs.yml)
 
 Visit the website for complete documentation: https://product-os.github.io/jellyfish-worker
+
+# Testing
+
+The integration tests require a postgres DB and redis server. The simplest way to run the tests locally is with docker-compose.
+
+```
+docker-compose -f docker-compose.yml up --build
+```
+
+The tests can then be run from your host with:
+
+```
+LOGLEVEL=warn POSTGRES_USER=docker POSTGRES_PASSWORD=docker make test-integration
+```

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,27 @@
+version: '2.1'
+
+services:
+  sut:
+    build:
+      context: .
+      dockerfile: Dockerfile.ci
+      args:
+        NPM_TOKEN: $NPM_TOKEN
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      - DATABASE=postgres
+      - LOGLEVEL=crit
+      - NODE_ENV=test
+      - POSTGRES_DATABASE=jellyfish
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PASSWORD=docker
+      - POSTGRES_USER=docker
+      - REDIS_HOST=redis
+      - REDIS_PASSWORD=
+      - REDIS_PORT=6379
+      - CI=1
+      - NPM_TOKEN
+    networks:
+      - internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2.1'
+
+services:
+  postgres:
+    image: balena/open-balena-db:4.1.0
+    restart: always
+    networks:
+      - internal
+    ports:
+      - '5432:5432'
+  redis:
+    image: balena/balena-redis:0.0.3
+    command: [sh, -c, "redis-server /usr/local/etc/redis/redis.conf --save ''"]
+    restart: always
+    networks:
+      - internal
+    ports:
+      - '6379:6379'
+
+networks:
+  internal: {}

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,5 @@
 module.exports = {
 	preset: "ts-jest",
 	testEnvironment: "node",
+	verbose: true
 };

--- a/lib/executor.ts
+++ b/lib/executor.ts
@@ -4,7 +4,7 @@
  * Proprietary and confidential.
  */
 
-import Bluebird from 'bluebird';
+import * as Bluebird from 'bluebird';
 import * as errio from 'errio';
 import * as _ from 'lodash';
 import * as skhema from 'skhema';
@@ -26,7 +26,7 @@ import {
 } from './types';
 import { core, worker } from '@balena/jellyfish-types';
 
-const logger = getLogger(__filename);
+const logger = getLogger('worker');
 
 /**
  * @summary The "type" card type
@@ -731,7 +731,7 @@ export const insertCard = async (
 
 	object.type = `${typeCard.slug}@${typeCard.version}`;
 
-	let card = null;
+	let card: core.Contract | null = null;
 	if (object.slug) {
 		card = await jellyfish.getCardBySlug(
 			context,
@@ -788,7 +788,7 @@ export const replaceCard = async (
 
 	object.type = `${typeCard.slug}@${typeCard.version}`;
 
-	let card = null;
+	let card: core.Contract | null = null;
 	if (object.slug) {
 		card = await jellyfish.getCardBySlug(
 			context,
@@ -921,7 +921,7 @@ export const run = async (
 		action: core.ActionContract;
 		arguments: any;
 		timestamp: any;
-		epoch: any;
+		epoch?: any;
 		type: string;
 	},
 ) => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,9 +4,9 @@
  * Proprietary and confidential.
  */
 
-import Bluebird from 'bluebird';
-import errio from 'errio';
-import _ from 'lodash';
+import * as Bluebird from 'bluebird';
+import * as errio from 'errio';
+import * as _ from 'lodash';
 import { Operation } from 'fast-json-patch';
 import { v4 as uuidv4 } from 'uuid';
 import * as assert from '@balena/jellyfish-assert';
@@ -28,7 +28,8 @@ import * as utils from './utils';
 import * as triggers from './triggers';
 import CARDS from './cards';
 
-const logger = getLogger(__filename);
+// TODO: use a single logger instance for the worker
+const logger = getLogger('worker');
 
 export { triggers, errors, executor, CARDS, utils };
 

--- a/lib/transformers.spec.ts
+++ b/lib/transformers.spec.ts
@@ -4,8 +4,8 @@
  * Proprietary and confidential.
  */
 
-import sinon from 'sinon';
-import _ from 'lodash';
+import * as sinon from 'sinon';
+import * as _ from 'lodash';
 import { v4 as uuid } from 'uuid';
 import * as transformers from './transformers';
 import { core } from '@balena/jellyfish-types';

--- a/lib/transformers.ts
+++ b/lib/transformers.ts
@@ -4,15 +4,15 @@
  * Proprietary and confidential.
  */
 
-import Bluebird from 'bluebird';
-import _ from 'lodash';
-import skhema from 'skhema';
+import * as Bluebird from 'bluebird';
+import * as _ from 'lodash';
+import * as skhema from 'skhema';
 import { v4 as uuidv4 } from 'uuid';
 import { getLogger } from '@balena/jellyfish-logger';
 import { JSONSchema, core } from '@balena/jellyfish-types';
 import { LogContext, QueueWaitResult, EnqueueOptions } from './types';
 
-const logger = getLogger(__filename);
+const logger = getLogger('worker');
 
 export interface EvaluateOptions {
 	transformers: core.Contract[];

--- a/lib/triggers.ts
+++ b/lib/triggers.ts
@@ -4,14 +4,14 @@
  * Proprietary and confidential.
  */
 
-import _ from 'lodash';
-import jsone from 'json-e';
-import skhema from 'skhema';
+import * as _ from 'lodash';
+import * as skhema from 'skhema';
 import * as assert from '@balena/jellyfish-assert';
 import { JSONSchema, core, worker } from '@balena/jellyfish-types';
 import * as errors from './errors';
 import * as utils from './utils';
 import { LogContext, JellyfishKernel } from './types';
+import jsone = require('json-e');
 
 interface CompileContext {
 	timestamp: string;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,7 +10,7 @@ import { getLogger } from '@balena/jellyfish-logger';
 import { JSONSchema, core } from '@balena/jellyfish-types';
 import { LogContext, JellyfishKernel } from './types';
 
-const logger = getLogger(__filename);
+const logger = getLogger('worker');
 
 /**
  * @summary Get the current timestamp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1225,12 +1225,97 @@
       "integrity": "sha512-BiKycdNb/iwqYgelBc/mrttND6/eqpB4syqLvAbiVO9R9C220nDLWr7U23lt5F5/A6mkOlRcPzzrBHt3/h7lBA==",
       "dev": true
     },
+    "@balena/jellyfish-action-library": {
+      "version": "9.0.64",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-9.0.64.tgz",
+      "integrity": "sha512-30XO5yzErdXJlBn6yHmZntPdgz8K9+EIcIVEYlOMCINcTxaYRZz98+9s9x6EzVNIt7naIpvcze6t7xiVmcQkDQ==",
+      "dev": true,
+      "requires": {
+        "@balena/jellyfish-assert": "^1.1.7",
+        "@balena/jellyfish-environment": "^4.1.4",
+        "@balena/jellyfish-logger": "^2.1.28",
+        "@balena/jellyfish-mail": "^1.0.13",
+        "@balena/jellyfish-metrics": "^1.0.130",
+        "@balena/jellyfish-plugin-base": "^2.1.11",
+        "bcrypt": "^5.0.1",
+        "bluebird": "^3.7.2",
+        "blueimp-md5": "^2.18.0",
+        "date-fns": "^2.21.1",
+        "googleapis": "^67.1.1",
+        "is-uuid": "^1.0.2",
+        "lodash": "^4.17.21",
+        "request-promise": "^4.2.6",
+        "skhema": "^5.3.3",
+        "uuid": "^8.3.2"
+      }
+    },
     "@balena/jellyfish-assert": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.8.tgz",
       "integrity": "sha512-yMYE89Yy8aBlFtM7EF4adRCz6NdBkGy5JHuu1z5/7M+OhO69ynrwFIyCUzU4NdsqQ7lIbhsctlgEivn+xUMKmw==",
       "requires": {
         "lodash": "^4.17.21"
+      }
+    },
+    "@balena/jellyfish-client-sdk": {
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-2.19.1.tgz",
+      "integrity": "sha512-Owpwnfj4LVJQgljXz9psx1FCjYE9CZsBael4fLqMdNfPLv10zOAbi2VeRvyb7ZDWHmheXlzxpkKW21anpQsmWg==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.21.1",
+        "bluebird": "^3.7.2",
+        "common-tags": "^1.8.0",
+        "deep-copy": "^1.4.2",
+        "fast-json-patch": "^3.0.0-1",
+        "is-uuid": "^1.0.2",
+        "lodash": "^4.17.21",
+        "socket.io-client": "^2.4.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@balena/jellyfish-core": {
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.13.5.tgz",
+      "integrity": "sha512-cWk7XR39g+ne00cA7XC63ict4JmAJAwcBEFE9dE0ZUvkG4FUz0xQ9vrGxwqkvOCGJUJgT+5dibgf5lj3ZBjLIQ==",
+      "dev": true,
+      "requires": {
+        "@balena/jellyfish-assert": "^1.1.7",
+        "@balena/jellyfish-environment": "^4.1.4",
+        "@balena/jellyfish-logger": "^2.1.28",
+        "@balena/jellyfish-metrics": "^1.0.130",
+        "@balena/jellyfish-uuid": "^1.0.84",
+        "bluebird": "^3.7.2",
+        "debounce-promise": "^3.1.2",
+        "fast-equals": "^2.0.1",
+        "fast-json-patch": "^2.2.1",
+        "json-e": "^4.4.1",
+        "json-schema-deref-sync": "^0.14.0",
+        "lodash": "^4.17.21",
+        "pg-format": "^1.0.4",
+        "pg-promise": "^10.10.1",
+        "redis": "^3.1.2",
+        "redis-mock": "^0.56.3",
+        "skhema": "^5.3.3",
+        "traverse": "^0.6.6",
+        "typed-errors": "^1.1.0"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "fast-json-patch": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+          "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1"
+          }
+        }
       }
     },
     "@balena/jellyfish-environment": {
@@ -1272,12 +1357,283 @@
         "winston-transport": "^4.4.0"
       }
     },
+    "@balena/jellyfish-mail": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-mail/-/jellyfish-mail-1.0.14.tgz",
+      "integrity": "sha512-vTEwhutXO3ZrCeN6llxbILhpdzA32zhxK+neYnBSKMKbVIv6tBCNZ0L+1pVS4easMxGLceoU80S+Ii9B1BNvuw==",
+      "dev": true,
+      "requires": {
+        "@balena/jellyfish-environment": "^4.1.5",
+        "request": "^2.88.2",
+        "request-promise": "^4.2.6"
+      },
+      "dependencies": {
+        "@balena/jellyfish-environment": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.1.5.tgz",
+          "integrity": "sha512-+xQ5NzfSbPThxyKe/7xNeL6a9EdAefwy+EXbgMr5JN3dUIYJKyJYFyf3JtMuO/QQ7R0VjA7VcDd4LsuZ5hvJmA==",
+          "dev": true,
+          "requires": {
+            "@humanwhocodes/env": "^2.2.0",
+            "lodash": "^4.17.21"
+          }
+        }
+      }
+    },
+    "@balena/jellyfish-metrics": {
+      "version": "1.0.131",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-1.0.131.tgz",
+      "integrity": "sha512-3SWvDIr8aFEt2aDum438LDW+9xYPp50iwyuUTWz5n4XoMsmV+dU8oTPvWbp4RdWunPUnpXgQc/sjPlMIaj40qg==",
+      "dev": true,
+      "requires": {
+        "@balena/jellyfish-environment": "^4.1.4",
+        "@balena/jellyfish-logger": "^2.1.29",
+        "@balena/jellyfish-types": "^0.5.43",
+        "@balena/node-metrics-gatherer": "^5.7.3",
+        "express": "^4.17.1",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@balena/jellyfish-assert": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.8.tgz",
+          "integrity": "sha512-yMYE89Yy8aBlFtM7EF4adRCz6NdBkGy5JHuu1z5/7M+OhO69ynrwFIyCUzU4NdsqQ7lIbhsctlgEivn+xUMKmw==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.21"
+          }
+        },
+        "@balena/jellyfish-logger": {
+          "version": "2.1.29",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-2.1.29.tgz",
+          "integrity": "sha512-so7bPstRPzXezWlnaHiBIF3tW801Wq5a1EBFaqB5Iw5eg1ttD7L92UXOAUOk9woc2cHHobzOhVA5LQ9VAv4nYA==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.8",
+            "@balena/jellyfish-environment": "^4.1.4",
+            "@sentry/node": "^6.3.0",
+            "errio": "^1.2.2",
+            "lodash": "^4.17.21",
+            "r7insight_node": "^2.1.1",
+            "typed-errors": "^1.1.0",
+            "winston": "^3.3.3",
+            "winston-transport": "^4.4.0"
+          }
+        }
+      }
+    },
+    "@balena/jellyfish-plugin-base": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.11.tgz",
+      "integrity": "sha512-KsAtt8jsN1bBUGXE1vdPwGvaIXaTOxdrVzWpQKXjs+Kfv4B3JwZlADPoriWafNOaS3EowBD+DMvzC3ugXrD2ig==",
+      "dev": true,
+      "requires": {
+        "@balena/jellyfish-logger": "^2.1.28",
+        "@balena/jellyfish-types": "^0.5.42",
+        "json-schema": "^0.3.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.5",
+        "skhema": "^5.3.3"
+      },
+      "dependencies": {
+        "json-schema": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
+          "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==",
+          "dev": true
+        }
+      }
+    },
+    "@balena/jellyfish-plugin-default": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-9.1.6.tgz",
+      "integrity": "sha512-Y53sXKLDd1iMz0tpjRfxCRenL9OF/Bdt7BbHXR2ad4SUA8pWGOObC49cTjlKrpazPJDmP1zQjgUXPRA6VRXEKw==",
+      "dev": true,
+      "requires": {
+        "@balena/jellyfish-assert": "^1.0.67",
+        "@balena/jellyfish-client-sdk": "^2.18.6",
+        "@balena/jellyfish-environment": "^4.1.1",
+        "@balena/jellyfish-logger": "2.1.22",
+        "@balena/jellyfish-plugin-base": "^2.0.29",
+        "@octokit/auth-app": "^2.11.0",
+        "@octokit/plugin-retry": "^3.0.7",
+        "@octokit/plugin-throttling": "^3.4.1",
+        "@octokit/rest": "^18.3.5",
+        "bluebird": "^3.7.2",
+        "fast-json-patch": "^3.0.0-1",
+        "front-sdk": "^0.8.1",
+        "geoip-lite": "^1.4.2",
+        "intercom-client": "^2.11.0",
+        "is-uuid": "^1.0.2",
+        "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.21",
+        "lru-cache": "^6.0.0",
+        "marked": "^1.2.9",
+        "native-url": "^0.3.4",
+        "node-jose": "^2.0.0",
+        "pluralize": "^8.0.0",
+        "randomstring": "^1.1.5",
+        "request": "^2.88.2",
+        "request-promise": "^4.2.6",
+        "uuid": "^8.3.2",
+        "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "@balena/jellyfish-logger": {
+          "version": "2.1.22",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-2.1.22.tgz",
+          "integrity": "sha512-Nu1LDEqgGt/Hus7tlV3UFoni+6W75dPqqzHYZJ0dssOBaoFvlPEE0kN5sMHeYWIg1Sus04GGTg//uO3osWrZQw==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.5",
+            "@balena/jellyfish-environment": "^4.1.1",
+            "@sentry/node": "^6.2.5",
+            "errio": "^1.2.2",
+            "lodash": "^4.17.21",
+            "r7insight_node": "^2.1.0",
+            "typed-errors": "^1.1.0",
+            "winston": "^3.3.3",
+            "winston-transport": "^4.4.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        },
+        "yaml": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+          "dev": true
+        }
+      }
+    },
+    "@balena/jellyfish-queue": {
+      "version": "1.0.0-typescript-9505c2df9213e1c0467958cedc76aef2f2774e38",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-queue/-/jellyfish-queue-1.0.0-typescript-9505c2df9213e1c0467958cedc76aef2f2774e38.tgz",
+      "integrity": "sha512-K7pRg9/lWQuBeaAUWQvzzUIm08ESy5ExWyF1On/+At0YLrswdhk2y2BKu0l8DQY3PoZ5aoxewRTow78ntd1+xA==",
+      "dev": true,
+      "requires": {
+        "@balena/jellyfish-assert": "^1.1.7",
+        "@balena/jellyfish-environment": "^4.1.4",
+        "@balena/jellyfish-logger": "^2.1.27",
+        "@balena/jellyfish-metrics": "^1.0.123",
+        "bluebird": "^3.7.2",
+        "graphile-worker": "^0.10.0",
+        "is-uuid": "^1.0.2",
+        "jest-cli": "^26.6.3",
+        "lodash": "^4.17.21",
+        "typed-error": "^3.2.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "jest-cli": {
+          "version": "26.6.3",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+          "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^26.6.3",
+            "@jest/test-result": "^26.6.2",
+            "@jest/types": "^26.6.2",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.4",
+            "import-local": "^3.0.2",
+            "is-ci": "^2.0.0",
+            "jest-config": "^26.6.3",
+            "jest-util": "^26.6.2",
+            "jest-validate": "^26.6.2",
+            "prompts": "^2.0.1",
+            "yargs": "^15.4.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "@balena/jellyfish-types": {
       "version": "0.5.45",
       "resolved": "https://registry.npmjs.org/@balena/jellyfish-types/-/jellyfish-types-0.5.45.tgz",
       "integrity": "sha512-kYKhuGovo7Shpd7qUkPZ7RE3R2FUwLEQwIbBePwu/F21/n6CEaBV81exZ12VM0pnmht9tdpg0fjh+NNp8+Avow==",
       "requires": {
         "json-schema-to-typescript": "^10.1.4"
+      }
+    },
+    "@balena/jellyfish-uuid": {
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-uuid/-/jellyfish-uuid-1.0.84.tgz",
+      "integrity": "sha512-DIxlh0T3I7BDIj0+wd/HRj/2T3/f6qQHB072uiNo+hLmUHU4zDrl/5b05CnzYSwPcdt4NHP4Ynhj+EPi+7ShZw==",
+      "dev": true,
+      "requires": {
+        "@types/uuid": "^8.3.0",
+        "uuid": "^8.3.2"
       }
     },
     "@balena/lint": {
@@ -1310,6 +1666,22 @@
           "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w==",
           "dev": true
         }
+      }
+    },
+    "@balena/node-metrics-gatherer": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@balena/node-metrics-gatherer/-/node-metrics-gatherer-5.7.3.tgz",
+      "integrity": "sha512-zxl4+dMV21M4yjV+lZ+D4+ZT2gRGmikPyldXo37M6M+LqWN1XVGVp0GK5dromDlQtWXyq2SEshaGHgIOhMDy/Q==",
+      "dev": true,
+      "requires": {
+        "@types/debug": "^4.1.5",
+        "@types/express": "^4.17.2",
+        "@types/on-finished": "^2.3.1",
+        "debug": "^4.1.1",
+        "express": "^4.17.1",
+        "on-finished": "^2.3.0",
+        "prom-client": "^12.0.0",
+        "typed-error": "^3.2.0"
       }
     },
     "@bcoe/v8-coverage": {
@@ -1568,6 +1940,199 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
+    "@mapbox/node-pre-gyp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.4.tgz",
+      "integrity": "sha512-M669Qo4nRT7iDmQEjQYC7RU8Z6dpz9UmSbkJ1OFEja3uevCdLKh7IZZki7L1TZj02kRyl82snXFY8QqkyfowrQ==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.1",
+        "nopt": "^5.0.0",
+        "npmlog": "^4.1.2",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.4",
+        "tar": "^6.1.0"
+      }
+    },
+    "@octokit/auth-app": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-2.11.0.tgz",
+      "integrity": "sha512-tC0BjqyTEjReIBHogOjLjF3rc2n4xwjZcpOaUUhybDnqkrp7Gxj5n91aGUcIFgJ3MDYf+f3XZehQd2B4ijG+4w==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^5.4.11",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.0.3",
+        "@types/lru-cache": "^5.1.0",
+        "deprecation": "^2.3.1",
+        "lru-cache": "^6.0.0",
+        "universal-github-app-jwt": "^1.0.1",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/auth-token": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
+      "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.1.tgz",
+      "integrity": "sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.1.0.tgz",
+      "integrity": "sha512-Z9fDZVbGj4dFLErEoXUSuZhk3wJ8KVGnbrUwoPijsQ9EyNwOeQ+U2jSqaHUz8WtgIWf0aeO59oJyhMpWCKaabg==",
+      "dev": true
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz",
+      "integrity": "sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.11.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
+      "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
+      "dev": true
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.1.tgz",
+      "integrity": "sha512-vvWbPtPqLyIzJ7A4IPdTl+8IeuKAwMJ4LjvmqWOOdfSuqWQYZXq2CEd0hsnkidff2YfKlguzujHs/reBdAx8Sg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.13.1",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/plugin-retry": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.7.tgz",
+      "integrity": "sha512-n08BPfVeKj5wnyH7IaOWnuKbx+e9rSJkhDHMJWXLPv61625uWjsN8G7sAW3zWm9n9vnS4friE7LL/XLcyGeG8Q==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "@octokit/plugin-throttling": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.4.1.tgz",
+      "integrity": "sha512-qCQ+Z4AnL9OrXvV59EH3GzPxsB+WyqufoCjiCJXJxTbnt3W+leXbXw5vHrMp4NG9ltw00McFWIxIxNQAzLNoTA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.1",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.15",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz",
+      "integrity": "sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.7.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.5.3",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.3.tgz",
+      "integrity": "sha512-KPAsUCr1DOdLVbZJgGNuE/QVLWEaVBpFQwDAz/2Cnya6uW2wJ/P5RVGk0itx7yyN1aGa8uXm2pri4umEqG1JBA==",
+      "dev": true,
+      "requires": {
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "5.0.1"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.1.tgz",
+      "integrity": "sha512-UF/PL0y4SKGx/p1azFf7e6j9lB78tVwAFvnHtslzOJ6VipshYks74qm9jjTEDlCyaTmbhbk2h3Run5l0CtCF6A==",
+      "dev": true,
+      "requires": {
+        "@octokit/openapi-types": "^6.0.0"
+      }
+    },
     "@sentry/core": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.1.tgz",
@@ -1723,11 +2288,74 @@
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.33.tgz",
       "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ=="
     },
+    "@types/bluebird-global": {
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/@types/bluebird-global/-/bluebird-global-3.5.12.tgz",
+      "integrity": "sha512-nRtDpyG4+SZej9mTOMG9Omunbgw04nhmHzVB1qgQUwREAX2lumCmvn5EzwydUuj7b1D3nOjm6elXQyNarsBUFw==",
+      "dev": true,
+      "requires": {
+        "@types/bluebird": "*"
+      }
+    },
+    "@types/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "@types/connect": {
+      "version": "3.4.34",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
+      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/debug": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+      "dev": true
+    },
+    "@types/express": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
+      "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
+      "integrity": "sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "@types/glob": {
       "version": "7.1.3",
@@ -1786,10 +2414,31 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-6.0.1.tgz",
       "integrity": "sha512-vuL/tG01yKO//gmCmnV3OZhx2hs538t+7FpQq//sUV1sF6xiKi5V8F60dvAxe/HkC4+QaMCHqrm/akqlppTAkQ=="
     },
+    "@types/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-rNAPdomlIUX0i0cg2+I+Q1wOUr531zHBQ+cV/28PJ39bSPKjahatZZ2LMuhiguETkCgLVzfruw/ZvNMNkKoSzw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/lodash": {
       "version": "4.14.168",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
       "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+    },
+    "@types/lru-cache": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==",
+      "dev": true
+    },
+    "@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -1807,21 +2456,98 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/on-finished": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/on-finished/-/on-finished-2.3.1.tgz",
+      "integrity": "sha512-mzVYaYcFs5Jd2n/O6uYIRUsFRR1cHyZLRvkLCU0E7+G5WhY0qBDAR5fUCeZbvecYOSh9ikhlesyi2UfI8B9ckQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/pg": {
+      "version": "7.14.11",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-7.14.11.tgz",
+      "integrity": "sha512-EnZkZ1OMw9DvNfQkn2MTJrwKmhJYDEs5ujWrPfvseWNoI95N8B4HzU/Ltrq5ZfYxDX/Zg8mTzwr6UAyTjjFvXA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "^1.2.0",
+        "pg-types": "^2.2.0"
+      }
+    },
     "@types/prettier": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
       "integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA=="
     },
+    "@types/qs": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "dev": true
+    },
+    "@types/request": {
+      "version": "2.48.5",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@types/request-promise": {
+      "version": "4.1.47",
+      "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.47.tgz",
+      "integrity": "sha512-eRSZhAS8SMsrWOM8vbhxFGVZhTbWSJvaRKyufJTdIf4gscUouQvOBlfotPSPHbMR3S7kfkyKbhb1SWPmQdy3KQ==",
+      "dev": true,
+      "requires": {
+        "@types/bluebird": "*",
+        "@types/request": "*"
+      }
+    },
     "@types/semver": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
       "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ=="
+    },
+    "@types/serve-static": {
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
+      "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "@types/sinon": {
       "version": "10.0.0",
@@ -1847,6 +2573,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
       "dev": true
     },
     "@types/uuid": {
@@ -1955,6 +2687,31 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -1978,6 +2735,12 @@
           "dev": true
         }
       }
+    },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+      "dev": true
     },
     "agent-base": {
       "version": "6.0.2",
@@ -2067,6 +2830,54 @@
         "picomatch": "^2.0.4"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2099,16 +2910,34 @@
       "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
       "dev": true
     },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
+    "array-uniq": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+      "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0=",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
     "arrify": {
@@ -2125,6 +2954,12 @@
       "requires": {
         "safer-buffer": "~2.1.0"
       }
+    },
+    "assert-options": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.7.0.tgz",
+      "integrity": "sha512-7q9uNH/Dh8gFgpIIb9ja8PJEWA5AQy3xnBC8jtKs8K/gNVCr1K6kIvlm59HUyYgvM7oEDoLzGgPcGd9FqhtXEQ==",
+      "dev": true
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -2184,6 +3019,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "babel-jest": {
       "version": "26.6.3",
@@ -2262,6 +3106,12 @@
       "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
       "dev": true
     },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
+    },
     "backoff": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
@@ -2330,6 +3180,34 @@
         }
       }
     },
+    "base64-arraybuffer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "dev": true
+    },
+    "bcrypt": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.0.1.tgz",
+      "integrity": "sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==",
+      "dev": true,
+      "requires": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "node-addon-api": "^3.1.0"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -2338,6 +3216,12 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "before-after-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.1.tgz",
+      "integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==",
+      "dev": true
     },
     "bessel": {
       "version": "1.0.2",
@@ -2350,16 +3234,87 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
     },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "dev": true
+    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=",
+      "dev": true
+    },
+    "blob": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+      "dev": true
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "blueimp-md5": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+      "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q==",
+      "dev": true
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true
+        }
+      }
+    },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2416,16 +3371,50 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "dev": true
+    },
     "builtin-modules": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
       "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "dev": true
     },
     "cache-base": {
@@ -2443,6 +3432,16 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "call-me-maybe": {
@@ -2505,6 +3504,12 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "chokidar": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
@@ -2531,6 +3536,12 @@
           }
         }
       }
+    },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true
     },
     "ci-info": {
       "version": "2.0.0",
@@ -2636,10 +3647,22 @@
         }
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "codependency": {
@@ -2818,10 +3841,28 @@
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "dev": true
     },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
+    },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
     "compute-gcd": {
@@ -2850,6 +3891,12 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
     "consolidate": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
@@ -2858,6 +3905,29 @@
       "requires": {
         "bluebird": "^3.7.2"
       }
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -2880,6 +3950,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -2930,6 +4006,12 @@
         "which": "^2.0.1"
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2968,6 +4050,12 @@
         "type": "^1.0.1"
       }
     },
+    "dag-map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
+      "integrity": "sha1-6DefBBAA7VYfxRVHXB7SyF7s6Nc=",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2987,6 +4075,18 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.1.tgz",
+      "integrity": "sha512-m1WR0xGiC6j6jNFAyW4Nvh4WxAi4JF4w9jRJwSI8nBmNcyZXPcP9VUQG+6gHQXAmqaGEKDKhOqAtENDC941UkA==",
+      "dev": true
+    },
+    "debounce-promise": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/debounce-promise/-/debounce-promise-3.1.2.tgz",
+      "integrity": "sha512-rZHcgBkbYavBeD9ej6sP56XfG53d51CD4dnaw989YX/nZ/ZJfgRx/9ePKmTNiUiyQvh4mtrMoS3OAWW+yoYtpg==",
+      "dev": true
     },
     "debug": {
       "version": "4.2.0",
@@ -3083,6 +4183,18 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
+      "dev": true
+    },
     "depcheck": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-1.4.0.tgz",
@@ -3147,6 +4259,12 @@
         }
       }
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
     "deplint": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/deplint/-/deplint-1.1.3.tgz",
@@ -3209,10 +4327,28 @@
         }
       }
     },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true
+    },
     "deps-regex": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz",
       "integrity": "sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true
     },
     "detect-newline": {
@@ -3265,6 +4401,21 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
     "electron-to-chromium": {
       "version": "1.3.707",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.707.tgz",
@@ -3288,6 +4439,12 @@
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -3295,6 +4452,55 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "engine.io-client": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.1.tgz",
+      "integrity": "sha512-oVu9kBkGbcggulyVF0kz6BV3ganqUeqXvD79WOFKa+11oK692w1NyFkuEj4xrkFRpZhn92QOqTk4RQq5LiBXbQ==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "~1.3.0",
+        "component-inherit": "0.0.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.2.0",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
+        "ws": "~7.4.2",
+        "xmlhttprequest-ssl": "~1.5.4",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+      "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
+      "dev": true,
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "~0.0.7",
+        "base64-arraybuffer": "0.1.4",
+        "blob": "0.0.5",
+        "has-binary2": "~1.0.2"
       }
     },
     "enquirer": {
@@ -3340,6 +4546,12 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
+    },
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
@@ -3364,6 +4576,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
@@ -3411,6 +4629,12 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -3419,6 +4643,12 @@
         "d": "1",
         "es5-ext": "~0.10.14"
       }
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
     },
     "exec-sh": {
       "version": "0.3.6",
@@ -3522,6 +4752,85 @@
         "jest-matcher-utils": "^26.6.2",
         "jest-message-util": "^26.6.2",
         "jest-regex-util": "^26.0.0"
+      }
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "ext": {
@@ -3681,6 +4990,12 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
+    "fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==",
+      "dev": true
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -3688,6 +5003,15 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "fecha": {
@@ -3713,6 +5037,38 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3727,6 +5083,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "follow-redirects": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -3756,6 +5118,12 @@
       "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
       "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
     },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -3763,6 +5131,31 @@
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
+      }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "front-sdk": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/front-sdk/-/front-sdk-0.8.1.tgz",
+      "integrity": "sha512-Xhfnw06mp+dxik4ylk7rzmo+lKRMFGJH7Rq+BUl3GEi7Jo9lM6OZocqXpQKFSSoWDus2n2H6rhEKxTsDSgW7Tw==",
+      "dev": true,
+      "requires": {
+        "@types/bluebird-global": "^3.0.1",
+        "@types/lodash": "^4.14.54",
+        "@types/request": "^2.48.1",
+        "@types/request-promise": "^4.1.42",
+        "bluebird": "^3.5.0",
+        "body-parser": "^1.19.0",
+        "express": "^4.17.1",
+        "lodash": "^4.17.2",
+        "request": "^2.79.0",
+        "request-promise": "^4.2.2",
+        "typed-error": "^3.2.1"
       }
     },
     "fs-extra": {
@@ -3785,6 +5178,15 @@
         }
       }
     },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3803,6 +5205,82 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "gaxios": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.2.0.tgz",
+      "integrity": "sha512-Ms7fNifGv0XVU+6eIyL9LB7RVESeML9+cMvkwGS70xyD6w2Z80wl6RiqiJ9k1KFlJCUTQqFFc8tXmPQfSKUe8g==",
+      "dev": true,
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.3.0"
+      }
+    },
+    "gcp-metadata": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
+      "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
+      "dev": true,
+      "requires": {
+        "gaxios": "^4.0.0",
+        "json-bigint": "^1.0.0"
+      }
+    },
     "generic-names": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
@@ -3818,11 +5296,57 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
+    "geoip-lite": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.4.2.tgz",
+      "integrity": "sha512-1rUNqar68+ldSSlSMdpLZPAM+NRokIDzB2lpQFRHSOaDVqtmy25jTAWe0lM2GqWFeaA35RiLhF8GF0vvL+qOKA==",
+      "dev": true,
+      "requires": {
+        "async": "^2.1.1",
+        "colors": "^1.1.2",
+        "iconv-lite": "^0.4.13",
+        "ip-address": "^5.8.9",
+        "lazy": "^1.0.11",
+        "rimraf": "^2.5.2",
+        "yauzl": "^2.9.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
@@ -3895,11 +5419,122 @@
         "@types/glob": "*"
       }
     },
+    "google-auth-library": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.0.4.tgz",
+      "integrity": "sha512-o8irYyeijEiecTXeoEe8UKNEzV1X+uhR4b2oNdapDMZixypp0J+eHimGOyx5Joa3UAeokGngdtDLXtq9vDqG2Q==",
+      "dev": true,
+      "requires": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "google-p12-pem": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
+      "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
+      "dev": true,
+      "requires": {
+        "node-forge": "^0.10.0"
+      }
+    },
+    "googleapis": {
+      "version": "67.1.1",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-67.1.1.tgz",
+      "integrity": "sha512-WLYk8R4dpW/oIxXhj0PQGhu+eOUpQbtWYTCxx/jeENr4arE9UmV5qmz0h1Gs1SPF/O/8PjCQIsPwOuHAlj78GA==",
+      "dev": true,
+      "requires": {
+        "google-auth-library": "^7.0.2",
+        "googleapis-common": "^5.0.1"
+      }
+    },
+    "googleapis-common": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-5.0.2.tgz",
+      "integrity": "sha512-TL7qronKNZwE/XBvqshwzCPmZGq2gz/beXzANF7EVoO7FsQjOd7dk40DYrXkoCpvbnJHCQKWESq6NansiIPFqA==",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.2",
+        "gaxios": "^4.0.0",
+        "google-auth-library": "^7.0.2",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
+    },
+    "graphile-worker": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/graphile-worker/-/graphile-worker-0.10.0.tgz",
+      "integrity": "sha512-TGIBXb6SZYoyGgPXwsQZkOxIaLUoxkwtrttFDe6mXZhkx20mLU4La3OrmP0lJQ6T63eXu0m5Knj/A26ECZ77hw==",
+      "dev": true,
+      "requires": {
+        "@types/debug": "^4.1.2",
+        "@types/pg": "^7.14.3",
+        "chokidar": "^3.4.0",
+        "cosmiconfig": "^7.0.0",
+        "json5": "^2.1.3",
+        "pg": ">=6.5 <9",
+        "tslib": "^2.1.0",
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
     },
     "growly": {
       "version": "1.3.0",
@@ -3907,6 +5542,17 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true,
       "optional": true
+    },
+    "gtoken": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+      "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
+      "dev": true,
+      "requires": {
+        "gaxios": "^4.0.0",
+        "google-p12-pem": "^3.0.3",
+        "jws": "^4.0.0"
+      }
     },
     "handlebars": {
       "version": "4.7.7",
@@ -3946,10 +5592,45 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-binary2": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "dev": true,
+      "requires": {
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
+        }
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+      "dev": true
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
@@ -4064,6 +5745,33 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "htmlencode": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/htmlencode/-/htmlencode-0.0.4.tgz",
+      "integrity": "sha1-9+LWr74YqHp45jujMI51N2Z0Dj8=",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -4113,6 +5821,12 @@
       "requires": {
         "postcss": "^7.0.14"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "5.1.8",
@@ -4166,6 +5880,12 @@
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4179,6 +5899,18 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "intercom-client": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/intercom-client/-/intercom-client-2.11.0.tgz",
+      "integrity": "sha512-TmCOQiuLMEosVafEZsleN33j5yJ9/rq3RvfdLTJPLuASEuLFWD8va2FnaAtVXjE1QJSDZ7kU1oStTIBDMcnrNQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.3.4",
+        "htmlencode": "^0.0.4",
+        "lodash": "^4.17.15",
+        "request": "^2.88.0"
+      }
     },
     "interpret": {
       "version": "1.4.0",
@@ -4194,6 +5926,37 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "ip-address": {
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
+      "dev": true,
+      "requires": {
+        "jsbn": "1.1.0",
+        "lodash": "^4.17.15",
+        "sprintf-js": "1.1.2"
+      },
+      "dependencies": {
+        "jsbn": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+          "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA=",
+          "dev": true
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+          "dev": true
+        }
+      }
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -4331,10 +6094,42 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true
     },
     "is-potential-custom-element-name": {
@@ -4364,6 +6159,21 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-uuid": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-uuid/-/is-uuid-1.0.2.tgz",
+      "integrity": "sha1-rRiY3fFUlHwlyOVJZvSGBOnK7MQ=",
+      "dev": true
+    },
+    "is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
+      "dev": true,
+      "requires": {
+        "is-invalid-path": "^0.1.0"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -5188,6 +6998,15 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "json-e": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/json-e/-/json-e-4.4.1.tgz",
@@ -5214,6 +7033,22 @@
       "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
       "requires": {
         "lodash": "^4.17.4"
+      }
+    },
+    "json-schema-deref-sync": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.14.0.tgz",
+      "integrity": "sha512-yGR1xmhdiD6R0MSrwWcFxQzAj5b3i5Gb/mt5tvQKgFMMeNe0KZYNEN/jWr7G+xn39Azqgcvk4ZKMs8dQl8e4wA==",
+      "dev": true,
+      "requires": {
+        "clone": "^2.1.2",
+        "dag-map": "~1.0.0",
+        "is-valid-path": "^0.1.1",
+        "lodash": "^4.17.13",
+        "md5": "~2.2.0",
+        "memory-cache": "~0.2.0",
+        "traverse": "~0.6.6",
+        "valid-url": "~1.0.9"
       }
     },
     "json-schema-faker": {
@@ -5330,6 +7165,53 @@
       "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-2.0.0.tgz",
       "integrity": "sha512-ksXaz9+3SIZ5BMxgr7MQueYcR515VRZPuoDhIymUd1JcF6BnVaYJS7k4NJni4EHhvJaOIGGiPqT8+ifsGp6mBw=="
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dev": true,
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "jwa": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+          "dev": true,
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+          "dev": true,
+          "requires": {
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5353,6 +7235,27 @@
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
     },
+    "jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dev": true,
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dev": true,
+      "requires": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -5369,6 +7272,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
+    "lazy": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+      "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA=",
+      "dev": true
     },
     "leven": {
       "version": "3.1.0",
@@ -5468,6 +7377,48 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "dev": true
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+      "dev": true
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+      "dev": true
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
@@ -5524,6 +7475,12 @@
         "ms": "^2.1.1",
         "triple-beam": "^1.3.0"
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -5618,9 +7575,26 @@
       }
     },
     "marked": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
-      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
+      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
+      "dev": true
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
     "memoizee": {
@@ -5645,6 +7619,18 @@
         }
       }
     },
+    "memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo=",
+      "dev": true
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
     "merge-source-map": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
@@ -5660,6 +7646,12 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
     "micromatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -5669,6 +7661,12 @@
         "braces": "^3.0.1",
         "picomatch": "^2.0.5"
       }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.47.0",
@@ -5703,6 +7701,41 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -5786,10 +7819,25 @@
         "to-regex": "^3.0.1"
       }
     },
+    "native-url": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.3.4.tgz",
+      "integrity": "sha512-6iM8R99ze45ivyH8vybJ7X0yekIcPf5GgLV5K0ENCbmRcaRIDoj37BC8iLEmaaBfqqb8enuZ5p0uhY+lVAbAcA==",
+      "dev": true,
+      "requires": {
+        "querystring": "^0.2.0"
+      }
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true
     },
     "neo-async": {
@@ -5822,11 +7870,54 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node-addon-api": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
+      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
+    "node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "dev": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
+    },
+    "node-jose": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-2.0.0.tgz",
+      "integrity": "sha512-j8zoFze1gijl8+DK/dSXXqX7+o2lMYv1XS+ptnXgGV/eloQaqq1YjNtieepbKs9jBS4WTnMOqyKSaQuunJzx0A==",
+      "dev": true,
+      "requires": {
+        "base64url": "^3.0.1",
+        "buffer": "^5.5.0",
+        "es6-promise": "^4.2.8",
+        "lodash": "^4.17.15",
+        "long": "^4.0.0",
+        "node-forge": "^0.10.0",
+        "pako": "^1.0.11",
+        "process": "^0.11.10",
+        "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
+      }
     },
     "node-modules-regexp": {
       "version": "1.0.0",
@@ -5854,6 +7945,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
       "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
       "dev": true
+    },
+    "nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -5889,6 +7989,24 @@
       "requires": {
         "path-key": "^3.0.0"
       }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -5943,6 +8061,12 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.1.1.tgz",
       "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ=="
     },
+    "object-inspect": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
+      "dev": true
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -5959,6 +8083,15 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
       }
     },
     "once": {
@@ -6085,6 +8218,18 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
+      "dev": true
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6098,6 +8243,24 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true
+    },
+    "parseqs": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
+      "dev": true
+    },
+    "parseuri": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
+      "dev": true
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
     },
     "pascalcase": {
@@ -6152,11 +8315,102 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "pg": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.5.1.tgz",
+      "integrity": "sha512-9wm3yX9lCfjvA98ybCyw2pADUivyNWT/yIP4ZcDVpMN0og70BUWYEGXPCTAQdGTAqnytfRADb7NERrY1qxhIqw==",
+      "dev": true,
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.4.0",
+        "pg-pool": "^3.2.2",
+        "pg-protocol": "^1.4.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      }
+    },
+    "pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
+      "dev": true
+    },
+    "pg-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
+      "integrity": "sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4=",
+      "dev": true
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true
+    },
+    "pg-minify": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.2.tgz",
+      "integrity": "sha512-1KdmFGGTP6jplJoI8MfvRlfvMiyBivMRP7/ffh4a11RUFJ7kC2J0ZHlipoKiH/1hz+DVgceon9U2qbaHpPeyPg==",
+      "dev": true
+    },
+    "pg-pool": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.3.0.tgz",
+      "integrity": "sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg==",
+      "dev": true
+    },
+    "pg-promise": {
+      "version": "10.10.1",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.10.1.tgz",
+      "integrity": "sha512-sopmuOr2PrUNh3XI0Y15ssmjcwhZnGHyGYwuDDmWFnBydq7lvrhTMBI3hefAp3YMx07+HSXfSpJse9z5vC4bsw==",
+      "dev": true,
+      "requires": {
+        "assert-options": "0.7.0",
+        "pg": "8.5.1",
+        "pg-minify": "1.6.2",
+        "spex": "3.2.0"
+      }
+    },
+    "pg-protocol": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==",
+      "dev": true
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
+      "dev": true,
+      "requires": {
+        "split2": "^3.1.1"
+      }
     },
     "picomatch": {
       "version": "2.2.2",
@@ -6190,6 +8444,12 @@
       "requires": {
         "semver-compare": "^1.0.0"
       }
+    },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -6347,6 +8607,33 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "dev": true
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.0"
+      }
+    },
     "precond": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
@@ -6380,6 +8667,12 @@
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6391,6 +8684,15 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "prom-client": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
+      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+      "dev": true,
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "prompts": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
@@ -6399,6 +8701,16 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
       }
     },
     "psl": {
@@ -6438,6 +8750,12 @@
         "lodash": "^4.17.15"
       }
     },
+    "querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "dev": true
+    },
     "r7insight_node": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/r7insight_node/-/r7insight_node-2.1.1.tgz",
@@ -6456,6 +8774,33 @@
       "requires": {
         "drange": "^1.0.2",
         "ret": "^0.2.0"
+      }
+    },
+    "randomstring": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/randomstring/-/randomstring-1.1.5.tgz",
+      "integrity": "sha1-bfBij3XL1ZMpMNn+OrTpVqGFGMM=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.2"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
       }
     },
     "react-is": {
@@ -6544,6 +8889,45 @@
         "backoff": "~2.5.0"
       }
     },
+    "redis": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "dev": true,
+      "requires": {
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+      "dev": true
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
+      "dev": true
+    },
+    "redis-mock": {
+      "version": "0.56.3",
+      "resolved": "https://registry.npmjs.org/redis-mock/-/redis-mock-0.56.3.tgz",
+      "integrity": "sha512-ynaJhqk0Qf3Qajnwvy4aOjS4Mdf9IBkELWtjd+NYhpiqu4QCNq6Vf3Q7c++XRPGiKiwRj9HWr0crcwy7EiPjYQ==",
+      "dev": true
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "dev": true,
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -6615,6 +8999,30 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
+        }
+      }
+    },
+    "request-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
+      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
         }
       }
     },
@@ -7053,6 +9461,64 @@
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -7090,6 +9556,12 @@
           }
         }
       }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -7132,6 +9604,17 @@
       "requires": {
         "onigasm": "^2.2.5",
         "vscode-textmate": "^5.2.0"
+      }
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
       }
     },
     "signal-exit": {
@@ -7354,6 +9837,76 @@
         }
       }
     },
+    "socket.io-client": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.4.0.tgz",
+      "integrity": "sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==",
+      "dev": true,
+      "requires": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "~1.3.0",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.5.0",
+        "has-binary2": "~1.0.2",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
+        "socket.io-parser": "~3.3.0",
+        "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
+      "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "~1.3.0",
+        "debug": "~3.1.0",
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7426,6 +9979,12 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "spex": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-3.2.0.tgz",
+      "integrity": "sha512-9srjJM7NaymrpwMHvSmpDeIK5GoRMX/Tq0E8aOlDPS54dDnDUIp30DrP9SphMPEETDLzEM9+4qo+KipmbtPecg==",
+      "dev": true
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -7433,6 +9992,15 @@
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
+      }
+    },
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -7507,6 +10075,12 @@
           }
         }
       }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -7620,6 +10194,37 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "tar": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
+      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "dev": true,
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "dev": true,
+      "requires": {
+        "bintrees": "1.0.1"
+      }
+    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -7689,6 +10294,12 @@
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+      "dev": true
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -7736,6 +10347,12 @@
         "is-number": "^7.0.0"
       }
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -7755,6 +10372,12 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
     },
     "triple-beam": {
       "version": "1.3.0",
@@ -7964,6 +10587,16 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
     "typed-error": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/typed-error/-/typed-error-3.2.1.tgz",
@@ -8003,6 +10636,14 @@
         "shelljs": "^0.8.4",
         "shiki": "^0.9.3",
         "typedoc-default-themes": "^0.12.10"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+          "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
+          "dev": true
+        }
       }
     },
     "typedoc-default-themes": {
@@ -8047,10 +10688,32 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
+    "universal-github-app-jwt": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.1.0.tgz",
+      "integrity": "sha512-3b+ocAjjz4JTyqaOT+NNBd5BtTuvJTxWElIoeHSVelUV9J3Jp7avmQTdLKCaoqi/5Ox2o/q+VK19TJ233rVXVQ==",
+      "dev": true,
+      "requires": {
+        "@types/jsonwebtoken": "^8.3.3",
+        "jsonwebtoken": "^8.5.1"
+      }
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "dev": true
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "unset-value": {
@@ -8107,6 +10770,12 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+      "dev": true
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -8117,6 +10786,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
     },
     "uuid": {
       "version": "8.3.2",
@@ -8141,6 +10816,12 @@
           "dev": true
         }
       }
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -8183,6 +10864,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
       "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -8274,6 +10961,48 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "winston": {
       "version": "3.3.3",
@@ -8386,6 +11115,18 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    },
     "y18n": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
@@ -8422,6 +11163,22 @@
       "version": "20.2.4",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
       "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,12 @@
   },
   "devDependencies": {
     "@balena/jellycheck": "^0.1.1",
+    "@balena/jellyfish-action-library": "^9.0.58",
+    "@balena/jellyfish-core": "^2.13.2",
+    "@balena/jellyfish-environment": "^4.1.4",
+    "@balena/jellyfish-plugin-base": "^2.1.11",
+    "@balena/jellyfish-plugin-default": "^9.1.4",
+    "@balena/jellyfish-queue": "1.0.0-typescript-9505c2df9213e1c0467958cedc76aef2f2774e38",
     "@balena/lint": "^5.4.1",
     "@types/jest": "^26.0.22",
     "@types/sinon": "^10.0.0",

--- a/test/integration/backend-helpers.ts
+++ b/test/integration/backend-helpers.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// TODO: Deep importing core modules in this way is an abomination
+// Additionally this code is exactly the same as the code found in the jellyfish queue module
+import { defaultEnvironment } from '@balena/jellyfish-environment';
+import { v4 as uuidv4 } from 'uuid';
+import * as utils from './utils';
+import {
+	JellyfishKernel,
+	Cache as JellyfishCache,
+	Context,
+} from '@balena/jellyfish-types/build/core';
+import {
+	Backend,
+	Kernel,
+	errors,
+	MemoryCache as Cache,
+} from '@balena/jellyfish-core';
+
+export interface BackendTestOptions {
+	suffix?: string;
+	skipConnect?: boolean;
+}
+
+export interface BackendCoreTestContext {
+	cache: JellyfishCache;
+	context: Context;
+	backend: JellyfishKernel['backend'];
+}
+
+const backendBefore = async (
+	context: Partial<BackendCoreTestContext>,
+	options: BackendTestOptions = {},
+): Promise<BackendCoreTestContext> => {
+	const suffix = options.suffix || uuidv4();
+	const dbName = `test_${suffix.replace(/-/g, '_')}`;
+
+	context.cache = new Cache(
+		Object.assign({}, defaultEnvironment.redis, {
+			namespace: dbName,
+		}),
+	);
+
+	context.context = {
+		id: `CORE-TEST-${uuidv4()}`,
+	};
+
+	if (context.cache) {
+		await context.cache.connect();
+	}
+
+	const backend = new Backend(
+		context.cache,
+		errors,
+		Object.assign({}, defaultEnvironment.database.options, {
+			database: dbName,
+		}),
+	);
+
+	if (!options.skipConnect) {
+		await backend.connect(context.context);
+	}
+
+	context.backend = backend;
+
+	return context as BackendCoreTestContext;
+};
+
+const backendAfter = async (context: BackendCoreTestContext): Promise<void> => {
+	/*
+	 * We can just disconnect and not destroy the whole
+	 * database as test databases are destroyed before
+	 * the next test run anyways.
+	 */
+	await context.backend.disconnect(context.context);
+
+	if (context.cache) {
+		await context.cache.disconnect();
+	}
+};
+
+export interface BackendGeneralTestContext {
+	kernel: JellyfishKernel;
+	generateRandomSlug: typeof utils.generateRandomSlug;
+	generateRandomID: typeof utils.generateRandomID;
+}
+
+export interface BackendTestContext
+	extends BackendCoreTestContext,
+		BackendGeneralTestContext {}
+
+export const before = async (
+	contextInput: Partial<BackendTestContext>,
+	options: { suffix?: string } = {},
+): Promise<BackendTestContext> => {
+	const context = (await backendBefore(contextInput, {
+		skipConnect: true,
+		suffix: options.suffix,
+	})) as BackendCoreTestContext & Partial<BackendGeneralTestContext>;
+
+	if (options.suffix) {
+		await context.backend.connect(context.context);
+		await context.backend.reset(context.context);
+	}
+
+	const kernel = new Kernel(context.backend);
+	await kernel.initialize(context.context);
+	context.kernel = kernel;
+	context.generateRandomSlug = utils.generateRandomSlug;
+	context.generateRandomID = utils.generateRandomID;
+
+	return context as BackendTestContext;
+};
+
+export const after = async (context: BackendTestContext): Promise<void> => {
+	await context.backend.drop(context.context);
+	await context.kernel.disconnect(context.context);
+	await backendAfter(context);
+};

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import { v4 as uuid } from 'uuid';
+import coreMixins = require('@balena/jellyfish-core/lib/cards/mixins');
+import PluginDefault = require('@balena/jellyfish-plugin-default');
+import ActionLibrary = require('@balena/jellyfish-action-library');
+
+import { PluginManager } from '@balena/jellyfish-plugin-base';
+
+const context = {
+	id: 'jellyfish-integration-test',
+};
+
+const pluginManager = new PluginManager(context, {
+	plugins: [PluginDefault as any, ActionLibrary as any],
+});
+
+export const loadDefaultCards = () => {
+	// TS-TODO: correctly type this
+	return pluginManager.getCards(context, coreMixins as any);
+};
+
+export const loadCards = () => {
+	const allCards: any = loadDefaultCards();
+	allCards['action-test-originator'] = Object.assign(
+		{},
+		allCards['action-create-card'],
+		{
+			slug: 'action-test-originator',
+		},
+	);
+	return allCards;
+};
+
+export const loadSyncIntegrations = () => {
+	return pluginManager.getSyncIntegrations(context);
+};
+
+export const loadActions = () => {
+	const allActions = pluginManager.getActions(context);
+	Object.assign(allActions, {
+		'action-test-originator': {
+			handler: async (session: string, ctx: any, card: any, request: any) => {
+				request.arguments.properties.data =
+					request.arguments.properties.data || {};
+				request.arguments.properties.data.originator = request.originator;
+				return allActions['action-create-card'].handler(
+					session,
+					ctx,
+					card,
+					request,
+				);
+			},
+		},
+	});
+	return allActions;
+};
+
+export const generateRandomID = (): string => {
+	return uuid();
+};
+
+export const generateRandomSlug = (
+	options: { prefix?: string } = {},
+): string => {
+	const slug = generateRandomID();
+	if (options.prefix) {
+		return `${options.prefix}-${slug}`;
+	}
+
+	return slug;
+};

--- a/test/integration/worker/execute.spec.ts
+++ b/test/integration/worker/execute.spec.ts
@@ -1,0 +1,1213 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import * as Bluebird from 'bluebird';
+import * as _ from 'lodash';
+import * as helpers from './helpers';
+
+let context: any;
+
+beforeAll(async () => {
+	context = await helpers.worker.before();
+
+	context.waitForMatch = async (waitQuery: any, times = 20) => {
+		if (times === 0) {
+			throw new Error('The wait query did not resolve');
+		}
+		const results = await context.jellyfish.query(
+			context.context,
+			context.session,
+			waitQuery,
+		);
+		if (results.length > 0) {
+			return results[0];
+		}
+		await Bluebird.delay(500);
+		return context.waitForMatch(waitQuery, times - 1);
+	};
+});
+
+afterAll(() => {
+	return helpers.worker.after(context);
+});
+
+describe('.execute()', () => {
+	test('should execute an action', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const request = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-card@1.0.0',
+				context: context.context,
+				card: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug: context.generateRandomSlug(),
+						version: '1.0.0',
+						data: {
+							foo: 'bar',
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const result = await context.queue.producer.waitResults(
+			context.context,
+			request,
+		);
+
+		expect(result.error).toBe(false);
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			result.data.id,
+		);
+		expect(card.data.foo).toBe('bar');
+	});
+
+	test('should execute a triggered action given a matching mode', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+
+		const command = context.generateRandomSlug();
+		context.worker.setTriggers(context.context, [
+			{
+				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command,
+								},
+							},
+						},
+					},
+				},
+				mode: 'insert',
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					reason: null,
+					properties: {
+						version: '1.0.0',
+						slug: command,
+					},
+				},
+			},
+		]);
+
+		const slug = context.generateRandomSlug();
+		const request = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: `${actionCard.slug}@${actionCard.version}`,
+				context: context.context,
+				card: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug,
+						version: '1.0.0',
+						data: {
+							command,
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const result = await context.queue.producer.waitResults(
+			context.context,
+			request,
+		);
+
+		expect(result.error).toBe(false);
+
+		const card = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command}@latest`,
+		);
+		expect(card).toBeTruthy();
+
+		const resultCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${slug}@latest`,
+		);
+
+		expect(resultCard.data.command).toBe(command);
+	});
+
+	test('should not execute a triggered action given a non matching mode', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+
+		const command = context.generateRandomSlug();
+		context.worker.setTriggers(context.context, [
+			{
+				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command,
+								},
+							},
+						},
+					},
+				},
+				mode: 'update',
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					reason: null,
+					properties: {
+						version: '1.0.0',
+						slug: command,
+					},
+				},
+			},
+		]);
+
+		const slug = context.generateRandomSlug();
+		const request = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: `${actionCard.slug}@${actionCard.version}`,
+				context: context.context,
+				card: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug,
+						version: '1.0.0',
+						data: {
+							command,
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const result = await context.queue.producer.waitResults(
+			context.context,
+			request,
+		);
+
+		expect(result.error).toBe(false);
+
+		const card = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command}@latest`,
+		);
+
+		expect(card).toBeFalsy();
+
+		const resultCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${slug}@latest`,
+		);
+
+		expect(resultCard.data.command).toBe(command);
+	});
+
+	test('should not execute a triggered action with a future start date', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+
+		const command = context.generateRandomSlug();
+		context.worker.setTriggers(context.context, [
+			{
+				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command,
+								},
+							},
+						},
+					},
+				},
+				startDate: '2500-01-01T00:00:00.000Z',
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					reason: null,
+					properties: {
+						version: '1.0.0',
+						slug: command,
+					},
+				},
+			},
+		]);
+
+		const slug = context.generateRandomSlug();
+		const request = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: `${actionCard.slug}@${actionCard.version}`,
+				context: context.context,
+				card: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug,
+						version: '1.0.0',
+						data: {
+							command,
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const result = await context.queue.producer.waitResults(
+			context.context,
+			request,
+		);
+
+		expect(result.error).toBe(false);
+
+		const card = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command}@latest`,
+		);
+
+		expect(card).toBeFalsy();
+	});
+
+	test('should execute a triggered action with a top level anyOf', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+
+		const command = context.generateRandomSlug();
+		context.worker.setTriggers(context.context, [
+			{
+				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					anyOf: [
+						{
+							properties: {
+								data: {
+									type: 'object',
+									required: ['command'],
+									properties: {
+										command: {
+											type: 'string',
+											const: command,
+										},
+									},
+								},
+							},
+						},
+						{
+							properties: {
+								data: {
+									type: 'string',
+								},
+							},
+						},
+					],
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					reason: null,
+					properties: {
+						version: '1.0.0',
+						slug: command,
+					},
+				},
+			},
+		]);
+
+		const slug = context.generateRandomSlug();
+		const request = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: `${actionCard.slug}@${actionCard.version}`,
+				context: context.context,
+				card: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					reason: null,
+					properties: {
+						version: '1.0.0',
+						slug,
+						data: {
+							command,
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const result = await context.queue.producer.waitResults(
+			context.context,
+			request,
+		);
+		expect(result.error).toBe(false);
+
+		const card = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command}@latest`,
+		);
+		expect(card).toBeTruthy();
+	});
+
+	test('should add a create event when creating a card', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+
+		const slug = context.generateRandomSlug();
+		const request = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: `${actionCard.slug}@${actionCard.version}`,
+				context: context.context,
+				card: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					reason: null,
+					properties: {
+						version: '1.0.0',
+						slug,
+						data: {
+							foo: 'bar',
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const result = await context.queue.producer.waitResults(
+			context.context,
+			request,
+		);
+		expect(result.error).toBe(false);
+
+		const timeline = await context.jellyfish.query(
+			context.context,
+			context.session,
+			{
+				type: 'object',
+				additionalProperties: true,
+				required: ['data'],
+				properties: {
+					data: {
+						type: 'object',
+						required: ['target'],
+						additionalProperties: true,
+						properties: {
+							target: {
+								type: 'string',
+								const: result.data.id,
+							},
+						},
+					},
+				},
+			},
+		);
+
+		expect(timeline.length).toBe(1);
+		expect(timeline[0].type).toBe('create@1.0.0');
+	});
+
+	test('should be able to AGGREGATE based on the card timeline', async () => {
+		const typeType = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'type@latest',
+		);
+
+		const slug = context.generateRandomSlug({ prefix: 'test-type' });
+		const request = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-card@1.0.0',
+				context: context.context,
+				card: typeType.id,
+				type: typeType.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug,
+						version: '1.0.0',
+						data: {
+							schema: {
+								type: 'object',
+								properties: {
+									type: {
+										type: 'string',
+										const: `${slug}@1.0.0`,
+									},
+									data: {
+										type: 'object',
+										properties: {
+											mentions: {
+												type: 'array',
+												$$formula:
+													'AGGREGATE($events, "data.payload.mentions")',
+											},
+										},
+										additionalProperties: true,
+									},
+								},
+								additionalProperties: true,
+								required: ['type', 'data'],
+							},
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const typeResult = await context.queue.producer.waitResults(
+			context.context,
+			request,
+		);
+		expect(typeResult.error).toBe(false);
+
+		const threadRequest = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-card@1.0.0',
+				context: context.context,
+				card: typeResult.data.id,
+				type: typeResult.data.type,
+				arguments: {
+					reason: null,
+					properties: {
+						version: '1.0.0',
+						slug: context.generateRandomSlug(),
+						data: {
+							mentions: [],
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const threadResult = await context.queue.producer.waitResults(
+			context.context,
+			threadRequest,
+		);
+		expect(threadResult.error).toBe(false);
+
+		const messageRequest1 = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-event@1.0.0',
+				context: context.context,
+				card: threadResult.data.id,
+				type: threadResult.data.type,
+				arguments: {
+					type: 'message',
+					payload: {
+						mentions: ['johndoe'],
+						message: 'Hello',
+					},
+				},
+			},
+		);
+
+		const messageRequest2 = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-event@1.0.0',
+				context: context.context,
+				card: threadResult.data.id,
+				type: threadResult.data.type,
+				arguments: {
+					type: 'message',
+					payload: {
+						mentions: ['janedoe', 'johnsmith'],
+						message: 'Hello',
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		await context.flush(context.session);
+		const messageResult1 = await context.queue.producer.waitResults(
+			context.context,
+			messageRequest1,
+		);
+		const messageResult2 = await context.queue.producer.waitResults(
+			context.context,
+			messageRequest2,
+		);
+
+		expect(messageResult1.error).toBe(false);
+		expect(messageResult2.error).toBe(false);
+
+		// AGGREGATE is asynchronous, so we will need to wait for the actions to be processed
+		const thread = await context.waitForMatch({
+			type: 'object',
+			properties: {
+				id: {
+					const: threadResult.data.id,
+				},
+				data: {
+					type: 'object',
+					properties: {
+						mentions: {
+							type: 'array',
+							minItems: 3,
+						},
+					},
+					required: ['mentions'],
+				},
+			},
+			required: ['id', 'data'],
+		});
+
+		expect(_.sortBy(thread.data.mentions)).toEqual(
+			_.sortBy(['johndoe', 'janedoe', 'johnsmith']),
+		);
+	});
+
+	test('AGGREGATE should create a property on the target if it does not exist', async () => {
+		const typeType = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'type@latest',
+		);
+
+		const slug = context.generateRandomSlug();
+		const request = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-card@1.0.0',
+				context: context.context,
+				card: typeType.id,
+				type: typeType.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug,
+						version: '1.0.0',
+						data: {
+							schema: {
+								type: 'object',
+								properties: {
+									type: {
+										type: 'string',
+										const: `${slug}@1.0.0`,
+									},
+									data: {
+										type: 'object',
+										properties: {
+											mentions: {
+												type: 'array',
+												$$formula:
+													'AGGREGATE($events, "data.payload.mentions")',
+											},
+										},
+										additionalProperties: true,
+									},
+								},
+								additionalProperties: true,
+								required: ['type', 'data'],
+							},
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const typeResult = await context.queue.producer.waitResults(
+			context.context,
+			request,
+		);
+		expect(typeResult.error).toBe(false);
+
+		const threadRequest = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-card@1.0.0',
+				context: context.context,
+				card: typeResult.data.id,
+				type: typeResult.data.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug: context.generateRandomSlug(),
+						version: '1.0.0',
+						data: {},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const threadResult = await context.queue.producer.waitResults(
+			context.context,
+			threadRequest,
+		);
+		expect(threadResult.error).toBe(false);
+
+		const messageRequest = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-event@1.0.0',
+				context: context.context,
+				card: threadResult.data.id,
+				type: threadResult.data.type,
+				arguments: {
+					type: 'message',
+					tags: [],
+					payload: {
+						mentions: ['johndoe'],
+						message: 'Hello',
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const messageResult = await context.queue.producer.waitResults(
+			context.context,
+			messageRequest,
+		);
+		expect(messageResult.error).toBe(false);
+
+		await expect(
+			context.waitForMatch({
+				type: 'object',
+				properties: {
+					id: {
+						const: threadResult.data.id,
+					},
+					data: {
+						type: 'object',
+						properties: {
+							mentions: {
+								type: 'array',
+								contains: {
+									const: 'johndoe',
+								},
+							},
+						},
+						required: ['mentions'],
+					},
+				},
+				required: ['id', 'data'],
+			}),
+		).resolves.toBeTruthy();
+	});
+
+	test('AGGREGATE should work with $$ prefixed properties', async () => {
+		const typeType = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'type@latest',
+		);
+
+		const slug = context.generateRandomSlug();
+		const request = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-card@1.0.0',
+				context: context.context,
+				card: typeType.id,
+				type: typeType.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug,
+						version: '1.0.0',
+						data: {
+							schema: {
+								type: 'object',
+								properties: {
+									type: {
+										type: 'string',
+										const: `${slug}@1.0.0`,
+									},
+									data: {
+										type: 'object',
+										properties: {
+											$$mentions: {
+												type: 'array',
+												$$formula:
+													'AGGREGATE($events, "data.payload[\'$$mentions\']")',
+											},
+										},
+										additionalProperties: true,
+									},
+								},
+								additionalProperties: true,
+								required: ['type', 'data'],
+							},
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const typeResult = await context.queue.producer.waitResults(
+			context.context,
+			request,
+		);
+
+		expect(typeResult.error).toBe(false);
+
+		const threadRequest = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-card@1.0.0',
+				context: context.context,
+				card: typeResult.data.id,
+				type: 'type',
+				arguments: {
+					reason: null,
+					properties: {
+						slug: context.generateRandomSlug(),
+						version: '1.0.0',
+						data: {
+							$$mentions: [],
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const threadResult = await context.queue.producer.waitResults(
+			context.context,
+			threadRequest,
+		);
+
+		expect(threadResult.error).toBe(false);
+
+		const messageRequest = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-event@1.0.0',
+				card: threadResult.data.id,
+				context: context.context,
+				type: slug,
+				arguments: {
+					type: 'message',
+					tags: [],
+					payload: {
+						$$mentions: ['johndoe'],
+						message: 'Hello',
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const messageResult = await context.queue.producer.waitResults(
+			context.context,
+			messageRequest,
+		);
+
+		expect(messageResult.error).toBe(false);
+
+		await expect(
+			context.waitForMatch({
+				type: 'object',
+				properties: {
+					id: {
+						const: threadResult.data.id,
+					},
+					data: {
+						type: 'object',
+						properties: {
+							$$mentions: {
+								type: 'array',
+								contains: {
+									const: 'johndoe',
+								},
+							},
+						},
+						required: ['$$mentions'],
+					},
+				},
+				required: ['id', 'data'],
+			}),
+		).resolves.toBeTruthy();
+	});
+
+	test('should create a message with tags', async () => {
+		const typeType = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'type@latest',
+		);
+
+		const slug = context.generateRandomSlug();
+		const request = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-card@1.0.0',
+				context: context.context,
+				card: typeType.id,
+				type: typeType.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug,
+						version: '1.0.0',
+						data: {
+							schema: {
+								type: 'object',
+								properties: {
+									type: {
+										type: 'string',
+										const: `${slug}@1.0.0`,
+									},
+								},
+								additionalProperties: true,
+								required: ['type'],
+							},
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const typeResult = await context.queue.producer.waitResults(
+			context.context,
+			request,
+		);
+		expect(typeResult.error).toBe(false);
+
+		const threadRequest = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-card@1.0.0',
+				context: context.context,
+				card: typeResult.data.id,
+				type: typeResult.data.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug: context.generateRandomSlug(),
+						version: '1.0.0',
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const threadResult = await context.queue.producer.waitResults(
+			context.context,
+			threadRequest,
+		);
+		expect(threadResult.error).toBe(false);
+
+		const messageRequest = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: 'action-create-event@1.0.0',
+				context: context.context,
+				card: threadResult.data.id,
+				type: threadResult.data.type,
+				arguments: {
+					type: 'message',
+					tags: ['testtag'],
+					payload: {
+						$$mentions: ['johndoe'],
+						message: 'Hello',
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const messageResult = await context.queue.producer.waitResults(
+			context.context,
+			messageRequest,
+		);
+
+		expect(messageResult.error).toBe(false);
+
+		const element = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			messageResult.data.id,
+			{
+				type: messageResult.data.type,
+			},
+		);
+
+		expect(element.tags).toEqual(['testtag']);
+	});
+
+	test('should add an execution event to the action request', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+
+		const request = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: `${actionCard.slug}@${actionCard.version}`,
+				context: context.context,
+				card: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug: context.generateRandomSlug(),
+						version: '1.0.0',
+						data: {
+							foo: 'bar',
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const result = await context.queue.producer.waitResults(
+			context.context,
+			request,
+		);
+		expect(result.error).toBe(false);
+
+		const timeline = await context.jellyfish.query(
+			context.context,
+			context.session,
+			{
+				type: 'object',
+				additionalProperties: true,
+				required: ['data'],
+				properties: {
+					data: {
+						type: 'object',
+						required: ['target'],
+						additionalProperties: true,
+						properties: {
+							target: {
+								type: 'string',
+								const: request.id,
+							},
+						},
+					},
+				},
+			},
+		);
+
+		expect(timeline.length).toBe(1);
+		expect(timeline[0].type).toBe('execute@1.0.0');
+	});
+
+	test('should execute a triggered action', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+
+		const command = context.generateRandomSlug();
+		context.worker.setTriggers(context.context, [
+			{
+				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command,
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					reason: null,
+					properties: {
+						version: '1.0.0',
+						slug: command,
+					},
+				},
+			},
+		]);
+
+		const slug = context.generateRandomSlug();
+		const request = await context.queue.producer.enqueue(
+			context.worker.getId(),
+			context.session,
+			{
+				action: `${actionCard.slug}@${actionCard.version}`,
+				context: context.context,
+				card: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug,
+						version: '1.0.0',
+						data: {
+							command,
+						},
+					},
+				},
+			},
+		);
+
+		await context.flush(context.session);
+		const result = await context.queue.producer.waitResults(
+			context.context,
+			request,
+		);
+
+		expect(result.error).toBe(false);
+
+		const card = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command}@latest`,
+		);
+
+		expect(card).toBeTruthy();
+
+		const resultCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${slug}@latest`,
+		);
+
+		expect(resultCard.data.command).toBe(command);
+	});
+});

--- a/test/integration/worker/executor.spec.ts
+++ b/test/integration/worker/executor.spec.ts
@@ -1,0 +1,2400 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import * as _ from 'lodash';
+import * as helpers from './helpers';
+import * as Bluebird from 'bluebird';
+import { errors, executor, utils } from '../../../lib';
+
+let context: any;
+
+beforeAll(async () => {
+	context = await helpers.jellyfish.before();
+
+	context.triggers = [];
+	context.stubQueue = [];
+	context.executeAction = (_session: string, request: any) => {
+		context.stubQueue.push(request);
+	};
+
+	context.actionContext = {
+		errors,
+		cards: context.jellyfish.cards,
+		getEventSlug: utils.getEventSlug,
+		privilegedSession: context.session,
+		context: context.context,
+		getCardById: (session: string, id: string, options: any) => {
+			return context.jellyfish.getCardById(
+				context.context,
+				session,
+				id,
+				options,
+			);
+		},
+		getCardBySlug: (session: string, slug: string, options: any) => {
+			return context.jellyfish.getCardBySlug(
+				context.context,
+				session,
+				slug,
+				options,
+			);
+		},
+		setTriggers: (ctx: any, triggers: any) => {
+			ctx.triggers = triggers;
+		},
+		insertCard: (session: string, typeCard: any, options: any, object: any) => {
+			return executor.insertCard(
+				context.context,
+				context.jellyfish,
+				session,
+				typeCard,
+				{
+					context: context.actionContext,
+					library: context.actionLibrary,
+					actor: context.actor.id,
+					currentTime: new Date(),
+					attachEvents: options.attachEvents,
+					executeAction: context.executeAction,
+				},
+				object,
+			);
+		},
+	};
+
+	context.waitForMatch = async (waitQuery: any, times = 20) => {
+		if (times === 0) {
+			throw new Error('The wait query did not resolve');
+		}
+		const results = await context.jellyfish.query(
+			context.context,
+			context.session,
+			waitQuery,
+		);
+		if (results.length > 0) {
+			return results[0];
+		}
+		await Bluebird.delay(500);
+		return context.waitForMatch(waitQuery, times - 1);
+	};
+});
+
+afterAll(() => {
+	return helpers.jellyfish.after(context);
+});
+
+describe('.replaceCard()', () => {
+	test('updating a card must have the correct tail', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const slug = context.generateRandomSlug();
+		const result1 = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				slug,
+				version: '1.0.0',
+				data: {
+					foo: 1,
+				},
+			},
+		);
+
+		await executor.replaceCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				slug,
+				version: '1.0.0',
+				data: {
+					foo: 2,
+				},
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			result1!.id,
+		);
+		expect(card).toEqual(
+			context.jellyfish.defaults({
+				created_at: result1!.created_at,
+				updated_at: card.updated_at,
+				linked_at: card.linked_at,
+				id: result1!.id,
+				name: null,
+				slug,
+				type: 'card@1.0.0',
+				data: {
+					foo: 2,
+				},
+			}),
+		);
+
+		const tail = await context.jellyfish.query(
+			context.context,
+			context.session,
+			{
+				type: 'object',
+				additionalProperties: true,
+				required: ['type', 'data'],
+				properties: {
+					type: {
+						type: 'string',
+						enum: ['create@1.0.0', 'update@1.0.0'],
+					},
+					data: {
+						type: 'object',
+						required: ['target'],
+						properties: {
+							target: {
+								type: 'string',
+								const: result1!.id,
+							},
+						},
+					},
+				},
+			},
+		);
+
+		// "Replace" is an operation that will go away once the database
+		// becomes fully immutable, so we don't attempt to calculate a
+		// JSON Patch update for it, as we treat it as an exception
+		expect(tail.length).toBe(1);
+		expect(tail[0].type).toBe('create@1.0.0');
+		expect(tail[0].data.payload).toEqual(
+			_.pick(result1, ['data', 'slug', 'type', 'version']),
+		);
+	});
+});
+
+describe('.insertCard()', () => {
+	test('should insert a card', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const slug = context.generateRandomSlug();
+		const result = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				slug,
+				data: {
+					foo: 1,
+				},
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			result!.id,
+		);
+		expect(card).toEqual(
+			context.jellyfish.defaults({
+				created_at: result!.created_at,
+				id: result!.id,
+				name: null,
+				slug,
+				type: 'card@1.0.0',
+				data: {
+					foo: 1,
+				},
+			}),
+		);
+	});
+
+	test('should ignore an explicit type property', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const slug = context.generateRandomSlug();
+		const result = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				active: true,
+				slug,
+				type: `${slug}@1.0.0`,
+				version: '1.0.0',
+				links: {},
+				tags: [],
+				markers: [],
+				requires: [],
+				capabilities: [],
+				data: {
+					foo: 1,
+				},
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			result!.id,
+		);
+		expect(card.type).toBe('card@1.0.0');
+	});
+
+	test('should default active to true', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const result = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			result!.id,
+		);
+		expect(card.active).toBe(true);
+	});
+
+	test('should be able to set active to false', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const result = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+				active: false,
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			result!.id,
+		);
+		expect(card.active).toBe(false);
+	});
+
+	test('should provide sane defaults for links', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const result = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			result!.id,
+		);
+		expect(card.links).toEqual({});
+	});
+
+	test('should provide sane defaults for tags', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const result = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			result!.id,
+		);
+		expect(card.tags).toEqual([]);
+	});
+
+	test('should provide sane defaults for data', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const result = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			result!.id,
+		);
+		expect(card.data).toEqual({});
+	});
+
+	test('should be able to set a slug', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const slug = context.generateRandomSlug();
+		const result = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				slug,
+				version: '1.0.0',
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			result!.id,
+		);
+		expect(card.slug).toBe(slug);
+	});
+
+	test('should be able to set a name', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const result = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+				name: 'Hello',
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			result!.id,
+		);
+		expect(card.name).toBe('Hello');
+	});
+
+	test('throw if card already exists and override is false', async () => {
+		const slug = context.generateRandomSlug();
+		await context.jellyfish.insertCard(context.context, context.session, {
+			slug,
+			type: 'card@1.0.0',
+			version: '1.0.0',
+		});
+
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		await expect(
+			executor.insertCard(
+				context.context,
+				context.jellyfish,
+				context.session,
+				typeCard,
+				{
+					currentTime: new Date(),
+					attachEvents: false,
+					context: context.actionContext,
+					library: context.actionLibrary,
+					actor: context.actor.id,
+					executeAction: context.executeAction,
+				},
+				{
+					version: '1.0.0',
+					slug,
+					active: false,
+				},
+			),
+		).rejects.toThrow(context.jellyfish.errors.JellyfishElementAlreadyExists);
+	});
+
+	test('should add a create event if attachEvents is true', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const result = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				version: '1.0.0',
+				slug: context.generateRandomSlug(),
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const tail = await context.jellyfish.query(
+			context.context,
+			context.session,
+			{
+				type: 'object',
+				additionalProperties: true,
+				required: ['type', 'data'],
+				properties: {
+					type: {
+						type: 'string',
+						const: 'create@1.0.0',
+					},
+					data: {
+						type: 'object',
+						required: ['target'],
+						properties: {
+							target: {
+								type: 'string',
+								const: result!.id,
+							},
+						},
+					},
+				},
+			},
+		);
+
+		expect(tail.length).toBe(1);
+	});
+
+	test('should pass a triggered action as an action originator', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const command = context.generateRandomSlug();
+		const triggers = [
+			{
+				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command,
+								},
+							},
+						},
+					},
+				},
+				action: 'action-test-originator',
+				target: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					properties: {
+						slug: command,
+					},
+				},
+				schedule: 'sync',
+			},
+		];
+
+		await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				library: Object.assign(
+					{
+						'action-test-originator': {
+							card: Object.assign(
+								{},
+								context.actionLibrary['action-create-card'].card,
+								{
+									slug: 'action-test-originator',
+								},
+							),
+							handler: async (
+								session: string,
+								ctx: any,
+								card: any,
+								request: any,
+							) => {
+								request.arguments.properties.data =
+									request.arguments.properties.data || {};
+								request.arguments.properties.data.originator =
+									request.originator;
+								return context.actionLibrary['action-create-card'].handler(
+									session,
+									ctx,
+									card,
+									request,
+								);
+							},
+						},
+					},
+					context.actionLibrary,
+				),
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+				triggers,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+				data: {
+					command,
+				},
+			},
+		);
+
+		const resultCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command}@1.0.0`,
+			{
+				type: typeCard.slug,
+			},
+		);
+
+		expect(resultCard.data.originator).toBe(
+			'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		);
+	});
+
+	test('should be able to override a triggered action originator', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const command = context.generateRandomSlug();
+		const triggers = [
+			{
+				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				schedule: 'sync',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command,
+								},
+							},
+						},
+					},
+				},
+				action: 'action-test-originator',
+				target: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					properties: {
+						slug: command,
+					},
+				},
+			},
+		];
+
+		await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				originator: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+				library: Object.assign(
+					{
+						'action-test-originator': {
+							card: Object.assign(
+								{},
+								context.actionLibrary['action-create-card'].card,
+								{
+									slug: 'action-test-originator',
+								},
+							),
+							handler: async (session, ctx, card, request) => {
+								request.arguments.properties.data =
+									request.arguments.properties.data || {};
+								request.arguments.properties.data.originator =
+									request.originator;
+								return context.actionLibrary['action-create-card'].handler(
+									session,
+									ctx,
+									card,
+									request,
+								);
+							},
+						},
+					},
+					context.actionLibrary,
+				),
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+				triggers,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+				data: {
+					command,
+				},
+			},
+		);
+
+		const resultCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command}@1.0.0`,
+			{
+				type: typeCard.slug,
+			},
+		);
+
+		expect(resultCard.data.originator).toBe(
+			'4a962ad9-20b5-4dd8-a707-bf819593cc84',
+		);
+	});
+
+	test('.insertCard() should execute one matching triggered action', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const command = context.generateRandomSlug();
+		const triggers = [
+			{
+				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				schedule: 'sync',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command,
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					properties: {
+						slug: command,
+					},
+				},
+			},
+		];
+
+		const result = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+				triggers,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+				data: {
+					command,
+				},
+			},
+		);
+
+		const tail = await context.jellyfish.query(
+			context.context,
+			context.session,
+			{
+				type: 'object',
+				additionalProperties: true,
+				required: ['type', 'data'],
+				properties: {
+					type: {
+						type: 'string',
+						const: 'create@1.0.0',
+					},
+					data: {
+						type: 'object',
+						required: ['target'],
+						properties: {
+							target: {
+								type: 'string',
+								const: result!.id,
+							},
+						},
+					},
+				},
+			},
+		);
+
+		expect(tail.length).toBe(1);
+		expect(context.stubQueue).toEqual([]);
+
+		const resultCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command}@1.0.0`,
+			{
+				type: typeCard.slug,
+			},
+		);
+
+		expect(resultCard).toBeTruthy();
+	});
+
+	test('should not execute non-matching triggered actions', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const command = context.generateRandomSlug();
+		const triggers = [
+			{
+				schedule: 'sync',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command,
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					properties: {
+						slug: command,
+					},
+				},
+			},
+		];
+
+		await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+				triggers,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+				data: {
+					command: context.generateRandomSlug(),
+				},
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const resultCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command}@1.0.0`,
+			{
+				type: typeCard.slug,
+			},
+		);
+
+		expect(resultCard).toBeFalsy();
+	});
+
+	test('should execute more than one matching triggered action', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const command1 = context.generateRandomSlug();
+		const command2 = context.generateRandomSlug();
+		const triggers = [
+			{
+				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				schedule: 'sync',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command1,
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					properties: {
+						slug: command1,
+					},
+				},
+			},
+			{
+				id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+				schedule: 'sync',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command1,
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					properties: {
+						slug: command2,
+					},
+				},
+			},
+		];
+
+		await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+				triggers,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+				data: {
+					command: command1,
+				},
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+
+		const resultCard1 = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command1}@1.0.0`,
+			{
+				type: typeCard.slug,
+			},
+		);
+
+		const resultCard2 = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command2}@1.0.0`,
+			{
+				type: typeCard.slug,
+			},
+		);
+
+		expect(resultCard1).toBeTruthy();
+		expect(resultCard2).toBeTruthy();
+	});
+
+	test('should execute the matching triggered actions given more than one', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const command1 = context.generateRandomSlug();
+		const command2 = context.generateRandomSlug();
+		const triggers = [
+			{
+				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				schedule: 'sync',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command1,
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					properties: {
+						slug: command1,
+					},
+				},
+			},
+			{
+				id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+				schedule: 'sync',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command2,
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					properties: {
+						slug: command2,
+					},
+				},
+			},
+		];
+
+		await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+				triggers,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+				data: {
+					command: command1,
+				},
+			},
+		);
+
+		expect(context.stubQueue).toEqual([]);
+
+		const resultCard1 = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command1}@1.0.0`,
+			{
+				type: typeCard.slug,
+			},
+		);
+
+		const resultCard2 = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command2}@1.0.0`,
+			{
+				type: typeCard.slug,
+			},
+		);
+
+		expect(resultCard1).toBeTruthy();
+		expect(resultCard2).toBeFalsy();
+	});
+
+	test('should remove previously inserted type triggered actions if inserting a type', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const fooType = context.generateRandomSlug({
+			prefix: 'foo',
+		});
+		const barType = context.generateRandomSlug({
+			prefix: 'bar',
+		});
+		const cards = [
+			{
+				type: 'triggered-action@1.0.0',
+				slug: context.generateRandomSlug({
+					prefix: 'triggered-action',
+				}),
+				version: '1.0.0',
+				data: {
+					type: `${fooType}@1.0.0`,
+					filter: {
+						type: 'object',
+						required: ['data'],
+						properties: {
+							data: {
+								type: 'object',
+								required: ['command'],
+								properties: {
+									command: {
+										type: 'string',
+										const: 'foo-bar-baz',
+									},
+								},
+							},
+						},
+					},
+					action: 'action-create-card@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						properties: {
+							slug: {
+								$eval: 'source.data.slug',
+							},
+							version: '1.0.0',
+							data: {
+								number: {
+									$eval: 'source.data.number',
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				type: 'triggered-action@1.0.0',
+				slug: context.generateRandomSlug({
+					prefix: 'triggered-action',
+				}),
+				version: '1.0.0',
+				data: {
+					type: `${barType}@1.0.0`,
+					filter: {
+						type: 'object',
+						required: ['data'],
+						properties: {
+							data: {
+								type: 'object',
+								required: ['command'],
+								properties: {
+									command: {
+										type: 'string',
+										const: 'foo-bar-baz',
+									},
+								},
+							},
+						},
+					},
+					action: 'action-create-card@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						properties: {
+							slug: {
+								$eval: 'source.data.slug',
+							},
+							version: '1.0.0',
+							data: {
+								number: {
+									$eval: 'source.data.number',
+								},
+							},
+						},
+					},
+				},
+			},
+		].map(context.kernel.defaults);
+
+		const insertedCards = await Bluebird.map(cards, (card) => {
+			return context.jellyfish.insertCard(
+				context.context,
+				context.session,
+				card,
+			);
+		});
+
+		await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			await context.jellyfish.getCardBySlug(
+				context.context,
+				context.session,
+				'type@latest',
+			),
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				slug: fooType,
+				version: '1.0.0',
+				data: {
+					schema: {
+						type: 'object',
+					},
+				},
+			},
+		);
+
+		const triggers = await context.jellyfish.query(
+			context.context,
+			context.session,
+			{
+				type: 'object',
+				additionalProperties: true,
+				required: ['active', 'type'],
+				properties: {
+					active: {
+						type: 'boolean',
+						const: true,
+					},
+					type: {
+						type: 'string',
+						const: 'triggered-action@1.0.0',
+					},
+					data: {
+						type: 'object',
+						required: ['type'],
+						properties: {
+							type: {
+								anyOf: [
+									{
+										type: 'string',
+										const: `${fooType}@1.0.0`,
+									},
+									{
+										type: 'string',
+										const: `${barType}@1.0.0`,
+									},
+								],
+							},
+						},
+					},
+				},
+			},
+		);
+		const updatedCard = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			insertedCards[1].id,
+		);
+
+		expect(triggers).toEqual([
+			Object.assign({}, updatedCard, {
+				id: triggers[0].id,
+			}),
+		]);
+	});
+
+	test('should add a triggered action given a type with an AGGREGATE formula', async () => {
+		const typeType = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'type@latest',
+		);
+
+		const slug = context.generateRandomSlug();
+		await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeType,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				executeAction: context.executeAction,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				setTriggers: context.actionContext.setTriggers,
+			},
+			{
+				slug,
+				version: '1.0.0',
+				data: {
+					schema: {
+						type: 'object',
+						properties: {
+							type: {
+								type: 'string',
+								const: `${slug}@1.0.0`,
+							},
+							data: {
+								type: 'object',
+								properties: {
+									mentions: {
+										type: 'array',
+										$$formula: 'AGGREGATE($events, "data.payload.mentions")',
+									},
+								},
+								additionalProperties: true,
+							},
+						},
+						additionalProperties: true,
+						required: ['type', 'data'],
+					},
+				},
+			},
+		);
+
+		const trigger = await context.waitForMatch({
+			type: 'object',
+			additionalProperties: true,
+			required: ['active', 'type'],
+			properties: {
+				active: {
+					type: 'boolean',
+					const: true,
+				},
+				type: {
+					type: 'string',
+					const: 'triggered-action@1.0.0',
+				},
+				data: {
+					type: 'object',
+					required: ['type'],
+					properties: {
+						type: {
+							type: 'string',
+							const: `${slug}@1.0.0`,
+						},
+					},
+				},
+			},
+		});
+
+		expect(trigger).toEqual({
+			created_at: trigger.created_at,
+			updated_at: null,
+			linked_at: trigger.linked_at,
+			id: trigger.id,
+			slug: `triggered-action-${slug}-data-mentions`,
+			type: trigger.type,
+			version: '1.0.0',
+			name: null,
+			active: true,
+			links: {},
+			tags: [],
+			markers: [],
+			requires: [],
+			capabilities: [],
+			data: {
+				schedule: 'async',
+				type: trigger.data.type,
+				target: trigger.data.target,
+				action: trigger.data.action,
+				arguments: trigger.data.arguments,
+				filter: trigger.data.filter,
+			},
+		});
+	});
+
+	test('should pre-register a triggered action if using AGGREGATE', async () => {
+		const typeType = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'type@latest',
+		);
+
+		let localTriggers: any[] = [];
+		const slug = context.generateRandomSlug();
+		await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeType,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				executeAction: context.executeAction,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				setTriggers: (_context: any, triggers: any[]) => {
+					localTriggers = triggers;
+				},
+			},
+			{
+				slug,
+				version: '1.0.0',
+				data: {
+					schema: {
+						type: 'object',
+						properties: {
+							type: {
+								type: 'string',
+								const: `${slug}@1.0.0`,
+							},
+							data: {
+								type: 'object',
+								properties: {
+									mentions: {
+										type: 'array',
+										$$formula: 'AGGREGATE($events, "data.payload.mentions")',
+									},
+								},
+								additionalProperties: true,
+							},
+						},
+						additionalProperties: true,
+						required: ['type', 'data'],
+					},
+				},
+			},
+		);
+
+		expect(localTriggers).toEqual([
+			{
+				schedule: 'async',
+				id: localTriggers[0].id,
+				slug: `triggered-action-${slug}-data-mentions`,
+				action: 'action-set-add@1.0.0',
+				target: {
+					$eval: "source.links['is attached to'][0].id",
+				},
+				filter: localTriggers[0].filter,
+				arguments: {
+					property: 'data.mentions',
+					value: {
+						$if: 'source.data.payload.mentions',
+						then: {
+							$eval: 'source.data.payload.mentions',
+						},
+						else: [],
+					},
+				},
+			},
+		]);
+	});
+
+	test('should update pre-registered triggered actions if removing an AGGREGATE', async () => {
+		const typeType = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'type@latest',
+		);
+
+		const localTriggers: any[] = [];
+		const slug = context.generateRandomSlug();
+		const element = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeType,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				executeAction: context.executeAction,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				setTriggers: context.actionContext.setTriggers,
+				triggers: localTriggers,
+			},
+			{
+				slug,
+				version: '1.0.0',
+				data: {
+					schema: {
+						type: 'object',
+						properties: {
+							type: {
+								type: 'string',
+								const: `${slug}@1.0.0`,
+							},
+							data: {
+								type: 'object',
+								properties: {
+									mentions: {
+										type: 'array',
+										$$formula: 'AGGREGATE($events, "data.payload.mentions")',
+									},
+								},
+								additionalProperties: true,
+							},
+						},
+						additionalProperties: true,
+						required: ['type', 'data'],
+					},
+				},
+			},
+		);
+
+		await executor.patchCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeType,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				executeAction: context.executeAction,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				setTriggers: context.actionContext.setTriggers,
+				triggers: localTriggers,
+			},
+			element!,
+			[
+				{
+					op: 'remove',
+					path: '/data/schema/properties/data/properties/mentions/$$formula',
+				},
+			],
+		);
+
+		expect(localTriggers).toEqual([]);
+	});
+
+	test('should add multiple triggered actions given a type with an AGGREGATE formula', async () => {
+		const typeType = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'type@latest',
+		);
+
+		const slug = context.generateRandomSlug();
+		const type = {
+			slug,
+			version: '1.0.0',
+			data: {
+				schema: {
+					type: 'object',
+					properties: {
+						type: {
+							type: 'string',
+							const: `${slug}@1.0.0`,
+						},
+						data: {
+							type: 'object',
+							properties: {
+								mentions: {
+									type: 'array',
+									$$formula: 'AGGREGATE($events, "data.payload.mentions")',
+								},
+							},
+							additionalProperties: true,
+						},
+					},
+					additionalProperties: true,
+					required: ['type', 'data'],
+				},
+			},
+		};
+
+		const element = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeType,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+				setTriggers: context.actionContext.setTriggers,
+			},
+			type,
+		);
+
+		await executor.patchCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeType,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+				setTriggers: context.actionContext.setTriggers,
+			},
+			element!,
+			[
+				{
+					op: 'replace',
+					path: '/active',
+					value: false,
+				},
+			],
+		);
+
+		await executor.patchCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeType,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+				setTriggers: context.actionContext.setTriggers,
+			},
+			element!,
+			[
+				{
+					op: 'replace',
+					path: '/active',
+					value: true,
+				},
+			],
+		);
+
+		const triggers = await context.jellyfish.query(
+			context.context,
+			context.session,
+			{
+				type: 'object',
+				additionalProperties: true,
+				required: ['active', 'type'],
+				properties: {
+					active: {
+						type: 'boolean',
+						const: true,
+					},
+					type: {
+						type: 'string',
+						const: 'triggered-action@1.0.0',
+					},
+					data: {
+						type: 'object',
+						required: ['type'],
+						properties: {
+							type: {
+								type: 'string',
+								const: `${slug}@1.0.0`,
+							},
+						},
+					},
+				},
+			},
+		);
+
+		expect(triggers.length).toBe(1);
+	});
+});
+
+describe('.patchCard()', () => {
+	test('should ignore pointless updates', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const result1 = await executor.insertCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+				active: true,
+			},
+		);
+
+		const result2 = await executor.patchCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			result1!,
+			[],
+		);
+
+		const result3 = await executor.patchCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			result1!,
+			[
+				{
+					op: 'replace',
+					path: '/active',
+					value: true,
+				},
+			],
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		expect(result1).toBeTruthy();
+		expect(result2).toBeFalsy();
+		expect(result3).toBeFalsy();
+
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			result1!.id,
+		);
+		expect(card.created_at).toBe(result1!.created_at);
+	});
+
+	test('should not upsert if no changes were made', async () => {
+		const element = await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			{
+				slug: context.generateRandomSlug(),
+				type: 'card@1.0.0',
+				version: '1.0.0',
+			},
+		);
+
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		await executor.patchCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			element,
+			[],
+		);
+
+		expect(context.stubQueue).toEqual([]);
+	});
+
+	test('should set a card to inactive', async () => {
+		const previousCard = await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			{
+				slug: context.generateRandomSlug(),
+				type: 'card@1.0.0',
+				version: '1.0.0',
+			},
+		);
+
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		await executor.patchCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			previousCard,
+			[
+				{
+					op: 'replace',
+					path: '/active',
+					value: false,
+				},
+			],
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const card = await context.jellyfish.getCardById(
+			context.context,
+			context.session,
+			previousCard.id,
+		);
+		expect(card.active).toBe(false);
+	});
+
+	test('should add an update event if attachEvents is true', async () => {
+		const element = await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			{
+				slug: context.generateRandomSlug(),
+				type: 'card@1.0.0',
+				version: '1.0.0',
+			},
+		);
+
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		const result = await executor.patchCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			typeCard,
+			{
+				currentTime: new Date(),
+				attachEvents: true,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			element,
+			[
+				{
+					op: 'replace',
+					path: '/active',
+					value: false,
+				},
+			],
+		);
+
+		expect(context.stubQueue).toEqual([]);
+		const tail = await context.jellyfish.query(
+			context.context,
+			context.session,
+			{
+				type: 'object',
+				additionalProperties: true,
+				required: ['type', 'data'],
+				properties: {
+					type: {
+						type: 'string',
+						const: 'update@1.0.0',
+					},
+					data: {
+						type: 'object',
+						required: ['target'],
+						properties: {
+							target: {
+								type: 'string',
+								const: result!.id,
+							},
+						},
+					},
+				},
+			},
+		);
+
+		expect(tail.length).toBe(1);
+	});
+
+	test('should remove previously inserted type triggered actions if deactivating a type', async () => {
+		const slug = context.generateRandomSlug();
+		const type = await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			{
+				type: 'type@1.0.0',
+				version: '1.0.0',
+				slug,
+				data: {
+					schema: {
+						type: 'object',
+					},
+				},
+			},
+		);
+
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+		await context.jellyfish.insertCard(context.context, context.session, {
+			type: 'triggered-action@1.0.0',
+			slug: context.generateRandomSlug({
+				prefix: 'triggered-action',
+			}),
+			version: '1.0.0',
+			data: {
+				type: `${slug}@1.0.0`,
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: 'foo-bar-baz',
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					properties: {
+						slug: {
+							$eval: 'source.data.slug',
+						},
+						data: {
+							number: {
+								$eval: 'source.data.number',
+							},
+						},
+					},
+				},
+			},
+		});
+
+		await executor.patchCard(
+			context.context,
+			context.jellyfish,
+			context.session,
+			await context.jellyfish.getCardBySlug(
+				context.context,
+				context.session,
+				'type@latest',
+			),
+			{
+				currentTime: new Date(),
+				attachEvents: false,
+				context: context.actionContext,
+				library: context.actionLibrary,
+				actor: context.actor.id,
+				executeAction: context.executeAction,
+			},
+			type,
+			[
+				{
+					op: 'replace',
+					path: '/active',
+					value: false,
+				},
+			],
+		);
+
+		const triggers = await context.jellyfish.query(
+			context.context,
+			context.session,
+			{
+				type: 'object',
+				additionalProperties: true,
+				required: ['active', 'type'],
+				properties: {
+					active: {
+						type: 'boolean',
+						const: true,
+					},
+					type: {
+						type: 'string',
+						const: 'triggered-action@1.0.0',
+					},
+					data: {
+						type: 'object',
+						required: ['type'],
+						properties: {
+							type: {
+								type: 'string',
+								const: `${slug}@1.0.0`,
+							},
+						},
+					},
+				},
+			},
+		);
+
+		expect(triggers).toEqual([]);
+	});
+});
+
+describe('.run()', () => {
+	test('should create a card', async () => {
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const slug = context.generateRandomSlug();
+		const result = await executor.run(
+			context.jellyfish,
+			context.session,
+			context.actionContext,
+			{
+				'action-create-card': context.actionLibrary['action-create-card'],
+			},
+			{
+				actor: context.actor.id,
+				context: context.context,
+				action: actionCard,
+				timestamp: '2018-07-04T00:22:52.247Z',
+				card: typeCard.id,
+				type: typeCard.type,
+				arguments: {
+					reason: null,
+					properties: {
+						slug,
+						version: '1.0.0',
+					},
+				},
+			},
+		);
+
+		expect(result).toEqual({
+			id: result.id,
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			slug,
+		});
+	});
+
+	test('should throw if the input card does not exist', async () => {
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+		await expect(
+			executor.run(
+				context.jellyfish,
+				context.session,
+				context.actionContext,
+				{
+					'action-create-card': context.actionLibrary['action-create-card'],
+				},
+				{
+					actor: context.actor.id,
+					action: actionCard,
+					context: context.context,
+					timestamp: '2018-07-04T00:22:52.247Z',
+					card: 'foobarbaz@9.9.9',
+					type: 'card@1.0.0',
+					arguments: {
+						properties: {
+							version: '1.0.0',
+							slug: 'foo-bar-baz',
+						},
+					},
+				},
+			),
+		).rejects.toThrow(errors.WorkerNoElement);
+	});
+
+	test('should throw if the actor does not exist', async () => {
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		await expect(
+			executor.run(
+				context.jellyfish,
+				context.session,
+				context.actionContext,
+				{
+					'action-create-card': context.actionLibrary['action-create-card'],
+				},
+				{
+					actor: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+					action: actionCard,
+					context: context.context,
+					timestamp: '2018-07-04T00:22:52.247Z',
+					card: typeCard.id,
+					type: typeCard.type,
+					arguments: {
+						properties: {
+							version: '1.0.0',
+							slug: 'foo-bar-baz',
+						},
+					},
+				},
+			),
+		).rejects.toThrow(errors.WorkerNoElement);
+	});
+
+	test('should throw if input card does not match the action filter', async () => {
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+		await expect(
+			executor.run(
+				context.jellyfish,
+				context.session,
+				context.actionContext,
+				{
+					'action-create-card': context.actionLibrary['action-create-card'],
+				},
+				{
+					actor: context.actor.id,
+					action: actionCard,
+					context: context.context,
+					timestamp: '2018-07-04T00:22:52.247Z',
+					card: actionCard.id,
+					type: actionCard.type,
+					arguments: {
+						properties: {
+							version: '1.0.0',
+							slug: 'foo-bar-baz',
+						},
+					},
+				},
+			),
+		).rejects.toThrow(errors.WorkerSchemaMismatch);
+	});
+
+	test('should throw if the arguments do not match the action', async () => {
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		await expect(
+			executor.run(
+				context.jellyfish,
+				context.session,
+				context.actionContext,
+				{
+					'action-create-card': context.actionLibrary['action-create-card'],
+				},
+				{
+					actor: context.actor.id,
+					action: actionCard,
+					context: context.context,
+					timestamp: '2018-07-04T00:22:52.247Z',
+					card: typeCard.id,
+					type: typeCard.type,
+					arguments: {
+						foo: 'bar',
+						bar: 'baz',
+					},
+				},
+			),
+		).rejects.toThrow(errors.WorkerSchemaMismatch);
+	});
+
+	test('should throw if the action has no corresponding implementation', async () => {
+		const actionCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'action-create-card@latest',
+		);
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		await expect(
+			executor.run(
+				context.jellyfish,
+				context.session,
+				context.actionContext,
+				{},
+				{
+					actor: context.actor.id,
+					action: actionCard,
+					context: context.context,
+					timestamp: '2018-07-04T00:22:52.247Z',
+					card: typeCard.id,
+					type: typeCard.type,
+					arguments: {
+						reason: null,
+						properties: {
+							version: '1.0.0',
+							slug: 'foo-bar-baz',
+						},
+					},
+				},
+			),
+		).rejects.toThrow(errors.WorkerInvalidAction);
+	});
+});

--- a/test/integration/worker/helpers.ts
+++ b/test/integration/worker/helpers.ts
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// import { fromObject } from 'errio';
+import { Worker } from '../../../lib/index';
+import * as _ from 'lodash';
+import * as errio from 'errio';
+import CARDS from '../../../lib/cards';
+import * as utils from '../utils';
+import * as Bluebird from 'bluebird';
+import { v4 as uuidv4 } from 'uuid';
+import * as helpers from '../backend-helpers';
+import {
+	// 	SessionContract,
+	UserContract,
+} from '@balena/jellyfish-types/build/core';
+import {
+	ActionPayload,
+	QueueConsumer,
+	QueueProducer,
+} from '@balena/jellyfish-types/build/queue';
+import * as queue from '@balena/jellyfish-queue';
+
+const Consumer = queue.Consumer;
+const Producer = queue.Producer;
+
+export interface IntegrationCoreTestContext {
+	session: string;
+	actor: UserContract;
+	queueActor: string;
+	dequeue: (times?: number) => Promise<ActionPayload | null>;
+	queue: {
+		consumer: QueueConsumer;
+		producer: QueueProducer;
+	};
+}
+
+export interface IntegrationTestContext
+	extends helpers.BackendTestContext,
+		IntegrationCoreTestContext {}
+
+const before = async (context: any = {}, options: any = {}) => {
+	await helpers.before(
+		context,
+		options && {
+			suffix: options.suffix,
+		},
+	);
+
+	context.allCards = utils.loadDefaultCards();
+	context.actionLibrary = utils.loadActions();
+
+	context.jellyfish = context.kernel;
+	context.session = context.jellyfish.sessions.admin;
+
+	const session = await context.jellyfish.getCardById(
+		context.context,
+		context.session,
+		context.session,
+	);
+	context.actor = await context.jellyfish.getCardById(
+		context.context,
+		context.session,
+		session.data.actor,
+	);
+
+	await context.jellyfish.insertCard(
+		context.context,
+		context.session,
+		context.allCards.message,
+	);
+	await context.jellyfish.insertCard(
+		context.context,
+		context.session,
+		context.allCards['role-user-community'],
+	);
+	await context.jellyfish.insertCard(
+		context.context,
+		context.session,
+		context.allCards['password-reset'],
+	);
+	await context.jellyfish.insertCard(
+		context.context,
+		context.session,
+		context.allCards['first-time-login'],
+	);
+
+	const actionCards = _.filter(context.allCards, (card) => {
+		return card.slug.startsWith('action-');
+	});
+
+	_.forEach(actionCards, async (actionCard) => {
+		await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			actionCard,
+		);
+	});
+
+	context.queue = {};
+	// test.context.queue.errors = queueErrors;
+
+	context.queue.consumer = new Consumer(context.jellyfish, context.session);
+
+	const consumedActionRequests: any[] = [];
+
+	await context.queue.consumer.initializeWithEventHandler(
+		context.context,
+		(actionRequest: any) => {
+			consumedActionRequests.push(actionRequest);
+		},
+	);
+
+	context.queueActor = uuidv4();
+
+	context.dequeue = async (times = 50) => {
+		if (consumedActionRequests.length === 0) {
+			if (times <= 0) {
+				return null;
+			}
+
+			await Bluebird.delay(10);
+			return context.dequeue(times - 1);
+		}
+
+		return consumedActionRequests.shift();
+	};
+
+	context.queue.producer = new Producer(context.jellyfish, context.session);
+
+	await context.queue.producer.initialize(context.context);
+	context.generateRandomSlug = utils.generateRandomSlug;
+	context.generateRandomID = utils.generateRandomID;
+};
+
+const after = async (context: any = {}) => {
+	if (context.queue) {
+		await context.queue.consumer.cancel();
+	}
+
+	if (context.jellyfish) {
+		await helpers.after(context);
+	}
+};
+
+export const jellyfish = {
+	before: async (context: any = {}) => {
+		await before(context);
+
+		await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			CARDS.update,
+		);
+		await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			CARDS.create,
+		);
+		await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			CARDS['triggered-action'],
+		);
+
+		return context;
+	},
+
+	after: (context: any) => {
+		return after(context);
+	},
+};
+
+export const worker = {
+	before: async (context: any = {}, options: any = {}) => {
+		await before(context, {
+			suffix: options.suffix,
+		});
+
+		context.worker = new Worker(
+			context.jellyfish,
+			context.session,
+			context.actionLibrary,
+			context.queue.consumer,
+			context.queue.producer,
+		);
+		await context.worker.initialize(context.context);
+
+		context.flush = async (session: string) => {
+			const request = await context.dequeue();
+
+			if (!request) {
+				throw new Error('No message dequeued');
+			}
+
+			const result = await context.worker.execute(session, request);
+
+			if (result.error) {
+				const Constructor =
+					context.worker.errors[result.data.name] ||
+					context.queue.errors[result.data.name] ||
+					context.jellyfish.errors[result.data.name] ||
+					Error;
+
+				const error = new Constructor(result.data.message);
+				error.stack = errio.fromObject(result.data).stack;
+				throw error;
+			}
+		};
+
+		context.processAction = async (session: string, action: any) => {
+			const createRequest = await context.queue.producer.enqueue(
+				context.worker.getId(),
+				session,
+				action,
+			);
+			await context.flush(session);
+			return context.queue.producer.waitResults(context, createRequest);
+		};
+
+		return context;
+	},
+	after,
+};

--- a/test/integration/worker/insert-card.spec.ts
+++ b/test/integration/worker/insert-card.spec.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import * as helpers from './helpers';
+
+let context: any;
+
+beforeAll(async () => {
+	try {
+		context = await helpers.worker.before(context);
+	} catch (error) {
+		console.error(error);
+	}
+});
+
+afterAll(async () => {
+	helpers.worker.after(context);
+});
+
+describe('.insertCard()', () => {
+	test.only('should pass a triggered action originator', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const command = context.generateRandomSlug();
+		context.worker.setTriggers(context.context, [
+			{
+				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
+				schedule: 'sync',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command,
+								},
+							},
+						},
+					},
+				},
+				action: 'action-test-originator@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					properties: {
+						slug: command,
+						version: '1.0.0',
+					},
+				},
+			},
+		]);
+
+		await context.worker.insertCard(
+			context.context,
+			context.session,
+			typeCard,
+			{
+				timestamp: new Date().toISOString(),
+				actor: context.actor.id,
+				attachEvents: true,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+				data: {
+					command,
+				},
+			},
+		);
+
+		const card = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command}@1.0.0`,
+		);
+		expect(card.data.originator).toBe('cb3523c5-b37d-41c8-ae32-9e7cc9309165');
+	});
+
+	test('should take an originator option', async () => {
+		const typeCard = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			'card@latest',
+		);
+
+		const command = context.generateRandomSlug();
+		context.worker.setTriggers(context.context, [
+			{
+				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
+				schedule: 'sync',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: command,
+								},
+							},
+						},
+					},
+				},
+				action: 'action-test-originator@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					properties: {
+						slug: command,
+					},
+				},
+			},
+		]);
+
+		await context.worker.insertCard(
+			context.context,
+			context.session,
+			typeCard,
+			{
+				timestamp: new Date().toISOString(),
+				actor: context.actor.id,
+				originator: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+				attachEvents: true,
+			},
+			{
+				slug: context.generateRandomSlug(),
+				version: '1.0.0',
+				data: {
+					command,
+				},
+			},
+		);
+
+		const card = await context.jellyfish.getCardBySlug(
+			context.context,
+			context.session,
+			`${command}@latest`,
+		);
+		expect(card.data.originator).toBe('4a962ad9-20b5-4dd8-a707-bf819593cc84');
+	});
+});

--- a/test/integration/worker/utils.spec.ts
+++ b/test/integration/worker/utils.spec.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import * as helpers from './helpers';
+import * as utils from '../../../lib/utils';
+import { v4 as uuidv4 } from 'uuid';
+
+let context: any;
+
+beforeAll(async () => {
+	try {
+		context = await helpers.jellyfish.before();
+	} catch (error) {
+		console.error('AN ERROR');
+		console.error(error);
+	}
+});
+
+afterAll(() => {
+	helpers.jellyfish.after(context);
+});
+
+describe('.hasCard()', () => {
+	test('id = yes (exists), slug = yes (exists)', async () => {
+		const card = await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			{
+				slug: context.generateRandomSlug(),
+				type: 'card@1.0.0',
+				version: '1.0.0',
+			},
+		);
+
+		expect(
+			await utils.hasCard(context.context, context.jellyfish, context.session, {
+				id: card.id,
+				version: '1.0.0',
+				slug: card.slug,
+			}),
+		).toBe(true);
+	});
+
+	test('id = yes (exists), slug = yes (not exist)', async () => {
+		const card = await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			{
+				slug: context.generateRandomSlug(),
+				type: 'card@1.0.0',
+				version: '1.0.0',
+			},
+		);
+
+		expect(
+			await utils.hasCard(context.context, context.jellyfish, context.session, {
+				id: card.id,
+				version: '1.0.0',
+				slug: context.generateRandomSlug(),
+			}),
+		).toBe(true);
+	});
+
+	test('id = yes (not exist), slug = yes (exists)', async () => {
+		const card = await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			{
+				slug: context.generateRandomSlug(),
+				type: 'card@1.0.0',
+				version: '1.0.0',
+			},
+		);
+
+		expect(
+			await utils.hasCard(context.context, context.jellyfish, context.session, {
+				id: uuidv4(),
+				version: '1.0.0',
+				slug: card.slug,
+			}),
+		).toBe(true);
+	});
+
+	test('id = yes (not exist), slug = yes (not exist)', async () => {
+		expect(
+			await utils.hasCard(context.context, context.jellyfish, context.session, {
+				id: uuidv4(),
+				version: '1.0.0',
+				slug: context.generateRandomSlug(),
+			}),
+		).toBe(false);
+	});
+
+	test('id = no, slug = yes (exists)', async () => {
+		const card = await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			{
+				slug: context.generateRandomSlug(),
+				type: 'card@1.0.0',
+				version: '1.0.0',
+			},
+		);
+
+		expect(
+			await utils.hasCard(context.context, context.jellyfish, context.session, {
+				version: '1.0.0',
+				slug: card.slug,
+			} as any),
+		).toBe(true);
+	});
+
+	test('id = no, slug = yes (not exist)', async () => {
+		expect(
+			await utils.hasCard(context.context, context.jellyfish, context.session, {
+				version: '1.0.0',
+				slug: context.generateRandomSlug(),
+			} as any),
+		).toBe(false);
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "build",
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "removeComments": true,
@@ -10,7 +10,8 @@
     "strict": true,
     "target": "es2015",
     "declaration": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noImplicitAny": false
   },
   "typedocOptions": {
     "excludePrivate": true,


### PR DESCRIPTION
This PR migrates the following integraiton tests from the main Jellyfish
repo:
- execute.spec
- executor.spec
- insert-card.spec
- utils.spec

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>