### PR TITLE
Exclude test source from build target

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "exclude": [
-    "lib/**/*.spec.ts"
+    "lib/**/*.spec.ts",
+    "test/**/*"
   ]
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Fix `tsconfig.build.json` to explicitly exclude all source stored under `test/`. Without this exclusion `build/` ends up with `lib/` and `test/` subdirectories which breaks imports by consumers who are expecting `build/index.js`.