### PR TITLE
transformer: artifactReady changes should re-trigger

### DIFF
--- a/lib/transformers.ts
+++ b/lib/transformers.ts
@@ -57,7 +57,8 @@ export const evaluate = async ({
 	if (!readyNow) {
 		return null;
 	}
-	const readyPreviously = oldCard.data?.$transformer?.artifactReady;
+	const artifactReadyChanged =
+		oldCard.data?.$transformer?.artifactReady !== readyNow;
 
 	await Bluebird.map(transformers, async (transformer: Transformer) => {
 		if (!transformer.data.inputFilter) {
@@ -70,7 +71,8 @@ export const evaluate = async ({
 			oldCard,
 		);
 
-		const shouldRun = matchesNow && (!matchedPreviously || !readyPreviously);
+		const shouldRun =
+			matchesNow && (!matchedPreviously || artifactReadyChanged);
 
 		if (!shouldRun) {
 			return;


### PR DESCRIPTION
after changing transformer to trigger when the inputFilter matches (independent of _when_ artifactReady became truthy) we lost re-triggering of transformers when `ready` changed from `truthy->other_truthy`