### PR TITLE
fix link creation trasformer->task

### DIFF
--- a/lib/transformers.ts
+++ b/lib/transformers.ts
@@ -124,7 +124,6 @@ export const evaluate = async ({
 			arguments: {
 				reason: null,
 				properties: {
-					type: 'link@1.0.0',
 					slug: `link-${transformer.id}-generated-${
 						result.data.id
 					}-${uuidv4()}`,


### PR DESCRIPTION
create action doesn't like specifying the type twice