### PR TITLE
allow transformers to match on card creation

### DIFF
--- a/lib/transformers.spec.ts
+++ b/lib/transformers.spec.ts
@@ -287,7 +287,7 @@ describe('.evaluate()', () => {
 		expect(executeSpy.notCalled).toBe(true);
 	});
 
-	test('should not create a task when a there is no previous card', async () => {
+	test('should create a task even when a there is no previous card', async () => {
 		const transformer = {
 			id: uuid(),
 			slug: 'test-transformer',
@@ -316,8 +316,22 @@ describe('.evaluate()', () => {
 
 		await transformers.evaluate(params);
 
-		// No actions were executed
-		expect(executeSpy.notCalled).toBe(true);
+		// Two actions were executed
+		expect(executeSpy.calledTwice).toBe(true);
+		// The first call was for a task
+		expect(executeSpy.firstCall.firstArg.card).toBe('task@1.0.0');
+		// The first call was to create a card
+		expect(executeSpy.firstCall.firstArg.action).toBe(
+			'action-create-card@1.0.0',
+		);
+
+		// The second call was for a link
+		expect(executeSpy.secondCall.firstArg.card).toBe('link@1.0.0');
+
+		// The second call was to create a card
+		expect(executeSpy.secondCall.firstArg.action).toBe(
+			'action-create-card@1.0.0',
+		);
 	});
 
 	test('should not create a task when card change is not relevant', async () => {

--- a/lib/transformers.ts
+++ b/lib/transformers.ts
@@ -47,9 +47,6 @@ export const evaluate = async ({
 	if (!transformers || !Array.isArray(transformers)) {
 		return null;
 	}
-	if (!oldCard) {
-		return null;
-	}
 
 	// Only run transformers with cards with a valid artifact (`data.$transformer.artifactReady` is truthy)
 	// and their input filter matches now, but didn't match before (or artifact wasn't ready)
@@ -58,7 +55,7 @@ export const evaluate = async ({
 		return null;
 	}
 	const artifactReadyChanged =
-		oldCard.data?.$transformer?.artifactReady !== readyNow;
+		oldCard?.data?.$transformer?.artifactReady !== readyNow;
 
 	await Bluebird.map(transformers, async (transformer: Transformer) => {
 		if (!transformer.data.inputFilter) {
@@ -68,7 +65,7 @@ export const evaluate = async ({
 		const matchesNow = skhema.isValid(transformer.data.inputFilter, newCard);
 		const matchedPreviously = skhema.isValid(
 			transformer.data.inputFilter,
-			oldCard,
+			oldCard || {},
 		);
 
 		const shouldRun =


### PR DESCRIPTION
we assumed there cannot be cards that are `artifactReady` on creation. 
For PRs that's not true anymore. Also, we might get rid of artifactReady and solely rely on transformer filters