### PR TITLE
Normalize trigger data format by using triggered-action contracts directly

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,7 +4,7 @@
  * Proprietary and confidential.
  */
 import { Kernel } from '@balena/jellyfish-core/build/kernel';
-import { core, worker, queue } from '@balena/jellyfish-types';
+import { core, queue } from '@balena/jellyfish-types';
 import {
 	Contract,
 	ContractData,
@@ -67,36 +67,6 @@ export interface WorkerContext {
 	cards: {
 		[slug: string]: ContractDefinition<ContractData>;
 	};
-}
-
-// TODO: just handle trigger contracts directly, as having 3 different structs for triggered-actions is super confusing
-// These objects are initially generated in the action server bootstrap code here https://github.com/product-os/jellyfish/blob/de4b77283d78403c861b4d966027cb71e71a8bac/apps/action-server/lib/bootstrap.js#L47
-// They also additional get parse by the `parseTrigger` function in index.ts
-export interface WorkerTriggerObjectInput {
-	id: string;
-	slug: string;
-	action: worker.TriggeredActionData2['action'];
-	target: worker.TriggeredActionData2['target'];
-	arguments: worker.TriggeredActionData2['arguments'];
-	interval?: worker.TriggeredActionData2['interval'];
-	filter?: worker.TriggeredActionData2['filter'];
-	mode?: worker.TriggeredActionData2['mode'];
-	// TS-TODO: figure out if startDate is used. This is part of the "tick()" spaghetti mess
-	startDate?: string;
-}
-
-// This is how triggers are stored in the state of the worker instance
-// TODO: Just work with trigger-action contracts directly
-export interface ParsedWorkerTriggerObject {
-	id: string;
-	slug: string;
-	action: worker.TriggeredActionData2['action'];
-	target: worker.TriggeredActionData2['target'];
-	arguments: worker.TriggeredActionData2['arguments'];
-	startDate?: any;
-	filter?: worker.TriggeredActionData2['filter'];
-	interval?: worker.TriggeredActionData2['interval'];
-	mode?: worker.TriggeredActionData2['mode'];
 }
 
 // tslint:disable: jsdoc-format

--- a/test/integration/insert-card.spec.ts
+++ b/test/integration/insert-card.spec.ts
@@ -10,6 +10,7 @@ import { strict as assert } from 'assert';
 import { Contract, TypeContract } from '@balena/jellyfish-types/build/core';
 import { v4 as uuid } from 'uuid';
 import _ from 'lodash';
+import { TriggeredActionContract } from '@balena/jellyfish-types/build/worker';
 
 let ctx: helpers.IntegrationTestContext;
 
@@ -35,35 +36,38 @@ describe('.insertCard()', () => {
 		const id = uuid();
 
 		ctx.worker.setTriggers(ctx.context, [
-			{
+			ctx.jellyfish.defaults({
 				id,
+				type: 'triggered-action@1.0.0',
 				slug: 'triggered-action-xr3523c5',
-				filter: {
-					type: 'object',
-					required: ['data'],
-					properties: {
-						data: {
-							type: 'object',
-							required: ['command'],
-							properties: {
-								command: {
-									type: 'string',
-									const: command,
+				data: {
+					filter: {
+						type: 'object',
+						required: ['data'],
+						properties: {
+							data: {
+								type: 'object',
+								required: ['command'],
+								properties: {
+									command: {
+										type: 'string',
+										const: command,
+									},
 								},
 							},
 						},
 					},
-				},
-				action: 'action-test-originator@1.0.0',
-				target: typeCard.id,
-				arguments: {
-					reason: null,
-					properties: {
-						slug: command,
-						version: '1.0.0',
+					action: 'action-test-originator@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						reason: null,
+						properties: {
+							slug: command,
+							version: '1.0.0',
+						},
 					},
 				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
 		await ctx.worker.insertCard(
@@ -109,34 +113,37 @@ describe('.insertCard()', () => {
 		const command = ctx.generateRandomSlug();
 		const id = uuid();
 		ctx.worker.setTriggers(ctx.context, [
-			{
+			ctx.jellyfish.defaults({
 				id,
 				slug: `triggered-action-foo-bar-${id.substr(0, 7)}`,
-				filter: {
-					type: 'object',
-					required: ['data'],
-					properties: {
-						data: {
-							type: 'object',
-							required: ['command'],
-							properties: {
-								command: {
-									type: 'string',
-									const: command,
+				type: 'triggered-action@1.0.0',
+				data: {
+					filter: {
+						type: 'object',
+						required: ['data'],
+						properties: {
+							data: {
+								type: 'object',
+								required: ['command'],
+								properties: {
+									command: {
+										type: 'string',
+										const: command,
+									},
 								},
 							},
 						},
 					},
-				},
-				action: 'action-test-originator@1.0.0',
-				target: typeCard.id,
-				arguments: {
-					reason: null,
-					properties: {
-						slug: command,
+					action: 'action-test-originator@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						reason: null,
+						properties: {
+							slug: command,
+						},
 					},
 				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
 		const originatorId = uuid();
@@ -183,34 +190,37 @@ describe('.insertCard()', () => {
 
 		const command = ctx.generateRandomSlug();
 		ctx.worker.setTriggers(ctx.context, [
-			{
+			ctx.jellyfish.defaults({
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
-				filter: {
-					type: 'object',
-					required: ['data'],
-					properties: {
-						data: {
-							type: 'object',
-							required: ['command'],
-							properties: {
-								command: {
-									type: 'string',
-									const: command,
+				type: 'triggered-action@1.0.0',
+				data: {
+					filter: {
+						type: 'object',
+						required: ['data'],
+						properties: {
+							data: {
+								type: 'object',
+								required: ['command'],
+								properties: {
+									command: {
+										type: 'string',
+										const: command,
+									},
 								},
 							},
 						},
 					},
-				},
-				action: 'action-create-card@1.0.0',
-				target: typeCard.id,
-				arguments: {
-					reason: null,
-					properties: {
-						slug: command,
+					action: 'action-create-card@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						reason: null,
+						properties: {
+							slug: command,
+						},
 					},
 				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
 		const result = await ctx.worker.insertCard(
@@ -278,33 +288,36 @@ describe('.insertCard()', () => {
 
 		const command = ctx.generateRandomSlug();
 		ctx.worker.setTriggers(ctx.context, [
-			{
+			ctx.jellyfish.defaults({
 				id: 'xb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar-xb3523c5',
-				filter: {
-					type: 'object',
-					required: ['data'],
-					properties: {
-						data: {
-							type: 'object',
-							required: ['command'],
-							properties: {
-								command: {
-									type: 'string',
-									const: command,
+				type: 'triggered-action@1.0.0',
+				data: {
+					filter: {
+						type: 'object',
+						required: ['data'],
+						properties: {
+							data: {
+								type: 'object',
+								required: ['command'],
+								properties: {
+									command: {
+										type: 'string',
+										const: command,
+									},
 								},
 							},
 						},
 					},
-				},
-				action: 'action-create-card@1.0.0',
-				target: typeCard.id,
-				arguments: {
-					properties: {
-						slug: command,
+					action: 'action-create-card@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						properties: {
+							slug: command,
+						},
 					},
 				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
 		await ctx.worker.insertCard(
@@ -350,62 +363,68 @@ describe('.insertCard()', () => {
 		const command1 = ctx.generateRandomSlug({ prefix });
 		const command2 = ctx.generateRandomSlug({ prefix });
 		ctx.worker.setTriggers(ctx.context, [
-			{
+			ctx.jellyfish.defaults({
 				id: uuid(),
 				slug: 'trigger-action-ib3523c5',
-				filter: {
-					type: 'object',
-					required: ['data'],
-					properties: {
-						data: {
-							type: 'object',
-							required: ['command'],
-							properties: {
-								command: {
-									type: 'string',
-									const: command1,
+				type: 'triggered-action@1.0.0',
+				data: {
+					filter: {
+						type: 'object',
+						required: ['data'],
+						properties: {
+							data: {
+								type: 'object',
+								required: ['command'],
+								properties: {
+									command: {
+										type: 'string',
+										const: command1,
+									},
 								},
 							},
 						},
 					},
-				},
-				action: 'action-create-card@1.0.0',
-				target: typeCard.id,
-				arguments: {
-					reason: null,
-					properties: {
-						slug: command1,
+					action: 'action-create-card@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						reason: null,
+						properties: {
+							slug: command1,
+						},
 					},
 				},
-			},
-			{
+			}) as TriggeredActionContract,
+			ctx.jellyfish.defaults({
 				id: uuid(),
 				slug: 'triggered-action-d67acdef',
-				filter: {
-					type: 'object',
-					required: ['data'],
-					properties: {
-						data: {
-							type: 'object',
-							required: ['command'],
-							properties: {
-								command: {
-									type: 'string',
-									const: command1,
+				type: 'triggered-action@1.0.0',
+				data: {
+					filter: {
+						type: 'object',
+						required: ['data'],
+						properties: {
+							data: {
+								type: 'object',
+								required: ['command'],
+								properties: {
+									command: {
+										type: 'string',
+										const: command1,
+									},
 								},
 							},
 						},
 					},
-				},
-				action: 'action-create-card@1.0.0',
-				target: typeCard.id,
-				arguments: {
-					reason: null,
-					properties: {
-						slug: command2,
+					action: 'action-create-card@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						reason: null,
+						properties: {
+							slug: command2,
+						},
 					},
 				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
 		await ctx.worker.insertCard(
@@ -457,62 +476,68 @@ describe('.insertCard()', () => {
 		const command1 = ctx.generateRandomSlug();
 		const command2 = ctx.generateRandomSlug();
 		ctx.worker.setTriggers(ctx.context, [
-			{
+			ctx.jellyfish.defaults({
 				id: uuid(),
 				slug: 'triggered-action-cx3523c5',
-				filter: {
-					type: 'object',
-					required: ['data'],
-					properties: {
-						data: {
-							type: 'object',
-							required: ['command'],
-							properties: {
-								command: {
-									type: 'string',
-									const: command1,
+				type: 'triggered-action@1.0.0',
+				data: {
+					filter: {
+						type: 'object',
+						required: ['data'],
+						properties: {
+							data: {
+								type: 'object',
+								required: ['command'],
+								properties: {
+									command: {
+										type: 'string',
+										const: command1,
+									},
 								},
 							},
 						},
 					},
-				},
-				action: 'action-create-card@1.0.0',
-				target: typeCard.id,
-				arguments: {
-					reason: null,
-					properties: {
-						slug: command1,
+					action: 'action-create-card@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						reason: null,
+						properties: {
+							slug: command1,
+						},
 					},
 				},
-			},
-			{
+			}) as TriggeredActionContract,
+			ctx.jellyfish.defaults({
 				id: uuid(),
 				slug: 'triggered-action-d68acdef',
-				filter: {
-					type: 'object',
-					required: ['data'],
-					properties: {
-						data: {
-							type: 'object',
-							required: ['command'],
-							properties: {
-								command: {
-									type: 'string',
-									const: command2,
+				type: 'triggered-action@1.0.0',
+				data: {
+					filter: {
+						type: 'object',
+						required: ['data'],
+						properties: {
+							data: {
+								type: 'object',
+								required: ['command'],
+								properties: {
+									command: {
+										type: 'string',
+										const: command2,
+									},
 								},
 							},
 						},
 					},
-				},
-				action: 'action-create-card@1.0.0',
-				target: typeCard.id,
-				arguments: {
-					reason: null,
-					properties: {
-						slug: command2,
+					action: 'action-create-card@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						reason: null,
+						properties: {
+							slug: command2,
+						},
 					},
 				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
 		await ctx.worker.insertCard(
@@ -890,6 +915,7 @@ describe('.insertCard()', () => {
 		const generatedTrigger = ctx.worker.getTriggers().find((trigger) => {
 			return (
 				_.get(trigger, [
+					'data',
 					'filter',
 					'$$links',
 					'is attached to',
@@ -900,25 +926,7 @@ describe('.insertCard()', () => {
 			);
 		});
 
-		expect(generatedTrigger).toEqual({
-			id: generatedTrigger!.id,
-			slug: `triggered-action-${slug}-data-mentions`,
-			action: 'action-set-add@1.0.0',
-			target: {
-				$eval: "source.links['is attached to'][0].id",
-			},
-			filter: generatedTrigger!.filter,
-			arguments: {
-				property: 'data.mentions',
-				value: {
-					$if: 'source.data.payload.mentions',
-					then: {
-						$eval: 'source.data.payload.mentions',
-					},
-					else: [],
-				},
-			},
-		});
+		expect(generatedTrigger).toBeTruthy();
 	});
 
 	test('should update pre-registered triggered actions if removing an AGGREGATE', async () => {

--- a/test/integration/tick.spec.ts
+++ b/test/integration/tick.spec.ts
@@ -7,151 +7,164 @@
 import * as _ from 'lodash';
 import { strict as assert } from 'assert';
 import * as helpers from './helpers';
+import { TriggeredActionContract } from '@balena/jellyfish-types/build/worker';
 
-let context: helpers.IntegrationTestContext;
+let ctx: helpers.IntegrationTestContext;
 
 beforeAll(async () => {
-	context = await helpers.before();
+	ctx = await helpers.before();
 });
 
 afterAll(() => {
-	return helpers.after(context);
+	return helpers.after(ctx);
 });
 
 describe('.tick()', () => {
 	it('should not enqueue actions if there are no triggers', async () => {
-		context.worker.setTriggers(context.context, []);
-		await context.worker.tick(context.context, context.session, {
+		ctx.worker.setTriggers(ctx.context, []);
+		await ctx.worker.tick(ctx.context, ctx.session, {
 			currentDate: new Date(),
 		});
 
-		const request = await context.dequeue();
+		const request = await ctx.dequeue();
 		expect(request).toBeFalsy();
 	});
 
 	it('should not enqueue actions if there are no time triggers', async () => {
-		context.worker.setTriggers(context.context, [
-			{
+		ctx.worker.setTriggers(ctx.context, [
+			ctx.jellyfish.defaults({
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
-				action: 'action-foo-bar@1.0.0',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				filter: {
-					type: 'object',
+				type: 'triggered-action@1.0.0',
+				data: {
+					action: 'action-foo-bar@1.0.0',
+					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+					filter: {
+						type: 'object',
+					},
+					arguments: {
+						foo: 'bar',
+					},
 				},
-				arguments: {
-					foo: 'bar',
-				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
-		await context.worker.tick(context.context, context.session, {
+		await ctx.worker.tick(ctx.context, ctx.session, {
 			currentDate: new Date(),
 		});
 
-		const request = await context.dequeue();
+		const request = await ctx.dequeue();
 		expect(request).toBeFalsy();
 	});
 
 	it('should not enqueue an action if there is a time trigger with a future start date', async () => {
-		context.worker.setTriggers(context.context, [
-			{
+		ctx.worker.setTriggers(ctx.context, [
+			ctx.jellyfish.defaults({
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
-				action: 'action-foo-bar@1.0.0',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				interval: 'PT1H',
-				startDate: '2018-09-05T12:00:00.000Z',
-				arguments: {
-					foo: 'bar',
+				type: 'triggered-action@1.0.0',
+				data: {
+					action: 'action-foo-bar@1.0.0',
+					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+					interval: 'PT1H',
+					startDate: '2018-09-05T12:00:00.000Z',
+					arguments: {
+						foo: 'bar',
+					},
 				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
-		await context.worker.tick(context.context, context.session, {
+		await ctx.worker.tick(ctx.context, ctx.session, {
 			currentDate: new Date('2018-08-05T12:00:00.000Z'),
 		});
 
-		const request = await context.dequeue();
+		const request = await ctx.dequeue();
 		expect(request).toBeFalsy();
 	});
 
 	it('should evaluate the current timestamp in a time triggered action', async () => {
-		const actionCard = await context.jellyfish.getCardBySlug(
-			context.context,
-			context.session,
+		const actionCard = await ctx.jellyfish.getCardBySlug(
+			ctx.context,
+			ctx.session,
 			'action-create-card@latest',
 		);
 
 		assert(actionCard !== null);
 
-		context.worker.setTriggers(context.context, [
-			{
+		ctx.worker.setTriggers(ctx.context, [
+			ctx.jellyfish.defaults({
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
-				action: `${actionCard.slug}@${actionCard.version}`,
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				interval: 'PT1D',
-				startDate: '2018-08-05T12:00:00.000Z',
-				arguments: {
-					reason: null,
-					properties: {
-						slug: 'foo',
-						data: {
-							timestamp: {
-								$eval: 'timestamp',
+				type: 'triggered-action@1.0.0',
+				data: {
+					action: `${actionCard.slug}@${actionCard.version}`,
+					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+					interval: 'PT1D',
+					startDate: '2018-08-05T12:00:00.000Z',
+					arguments: {
+						reason: null,
+						properties: {
+							slug: 'foo',
+							data: {
+								timestamp: {
+									$eval: 'timestamp',
+								},
 							},
 						},
 					},
 				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
-		await context.worker.tick(context.context, context.session, {
+		await ctx.worker.tick(ctx.context, ctx.session, {
 			currentDate: new Date('2018-08-06T12:00:00.000Z'),
 		});
 
 		// TS-TODO: Correctly type this
-		const request: any = await context.dequeue();
+		const request: any = await ctx.dequeue();
 		expect(request.data.arguments.properties.data).toEqual({
 			timestamp: '2018-08-06T12:00:00.000Z',
 		});
 	});
 
 	it('should enqueue an action if there is a time trigger with a past start date', async () => {
-		const actionCard = await context.jellyfish.getCardBySlug(
-			context.context,
-			context.session,
+		const actionCard = await ctx.jellyfish.getCardBySlug(
+			ctx.context,
+			ctx.session,
 			'action-create-card@latest',
 		);
 
 		assert(actionCard !== null);
 
-		context.worker.setTriggers(context.context, [
-			{
+		ctx.worker.setTriggers(ctx.context, [
+			ctx.jellyfish.defaults({
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
-				action: `${actionCard.slug}@${actionCard.version}`,
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				interval: 'PT1D',
-				startDate: '2018-08-05T12:00:00.000Z',
-				arguments: {
-					properties: {
-						version: '1.0.0',
-						slug: 'foo',
+				type: 'triggered-action@1.0.0',
+				data: {
+					action: `${actionCard.slug}@${actionCard.version}`,
+					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+					interval: 'PT1D',
+					startDate: '2018-08-05T12:00:00.000Z',
+					arguments: {
+						properties: {
+							version: '1.0.0',
+							slug: 'foo',
+						},
 					},
 				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
-		await context.worker.tick(context.context, context.session, {
+		await ctx.worker.tick(ctx.context, ctx.session, {
 			currentDate: new Date('2018-08-06T12:00:00.000Z'),
 		});
 
 		// TS-TODO: Correctly type this
-		const request: any = await context.dequeue();
+		const request: any = await ctx.dequeue();
 		expect(request).toEqual(
-			context.jellyfish.defaults({
+			ctx.jellyfish.defaults({
 				id: request.id,
 				created_at: request.created_at,
 				name: null,
@@ -162,9 +175,9 @@ describe('.tick()', () => {
 					input: {
 						id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 					},
-					context: context.context,
+					context: ctx.context,
 					action: `${actionCard.slug}@${actionCard.version}`,
-					actor: context.actor.id,
+					actor: ctx.actor.id,
 					originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 					timestamp: '2018-08-06T12:00:00.000Z',
 					epoch: 1533556800000,
@@ -180,37 +193,40 @@ describe('.tick()', () => {
 	});
 
 	it('should enqueue an action if there is a time trigger with a present start date', async () => {
-		const actionCard = await context.jellyfish.getCardBySlug(
-			context.context,
-			context.session,
+		const actionCard = await ctx.jellyfish.getCardBySlug(
+			ctx.context,
+			ctx.session,
 			'action-create-card@latest',
 		);
 		assert(actionCard !== null);
-		context.worker.setTriggers(context.context, [
-			{
+		ctx.worker.setTriggers(ctx.context, [
+			ctx.jellyfish.defaults({
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
-				action: `${actionCard.slug}@${actionCard.version}`,
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				interval: 'PT1D',
-				startDate: '2018-08-05T12:00:00.000Z',
-				arguments: {
-					properties: {
-						version: '1.0.0',
-						slug: 'foo',
+				type: 'triggered-action@1.0.0',
+				data: {
+					action: `${actionCard.slug}@${actionCard.version}`,
+					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+					interval: 'PT1D',
+					startDate: '2018-08-05T12:00:00.000Z',
+					arguments: {
+						properties: {
+							version: '1.0.0',
+							slug: 'foo',
+						},
 					},
 				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
-		await context.worker.tick(context.context, context.session, {
+		await ctx.worker.tick(ctx.context, ctx.session, {
 			currentDate: new Date('2018-08-05T12:00:00.000Z'),
 		});
 
 		// TS-TODO: Correctly type this
-		const request: any = await context.dequeue();
+		const request: any = await ctx.dequeue();
 		expect(request).toEqual(
-			context.jellyfish.defaults({
+			ctx.jellyfish.defaults({
 				id: request.id,
 				slug: request.slug,
 				name: null,
@@ -222,9 +238,9 @@ describe('.tick()', () => {
 					input: {
 						id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 					},
-					context: context.context,
+					context: ctx.context,
 					action: `${actionCard.slug}@${actionCard.version}`,
-					actor: context.actor.id,
+					actor: ctx.actor.id,
 					originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 					timestamp: '2018-08-05T12:00:00.000Z',
 					epoch: 1533470400000,
@@ -240,89 +256,98 @@ describe('.tick()', () => {
 	});
 
 	it('should not enqueue an action using a past timestamp', async () => {
-		const actionCard = await context.jellyfish.getCardBySlug(
-			context.context,
-			context.session,
+		const actionCard = await ctx.jellyfish.getCardBySlug(
+			ctx.context,
+			ctx.session,
 			'action-create-card@latest',
 		);
 		assert(actionCard !== null);
-		context.worker.setTriggers(context.context, [
-			{
+		ctx.worker.setTriggers(ctx.context, [
+			ctx.jellyfish.defaults({
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
-				action: `${actionCard.slug}@${actionCard.version}`,
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				interval: 'PT1H',
-				startDate: '2050-08-05T12:00:00.000Z',
-				arguments: {
-					properties: {
-						version: '1.0.0',
-						slug: 'foo',
+				type: 'triggered-action@1.0.0',
+				data: {
+					action: `${actionCard.slug}@${actionCard.version}`,
+					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+					interval: 'PT1H',
+					startDate: '2050-08-05T12:00:00.000Z',
+					arguments: {
+						properties: {
+							version: '1.0.0',
+							slug: 'foo',
+						},
 					},
 				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
-		await context.worker.tick(context.context, context.session, {
+		await ctx.worker.tick(ctx.context, ctx.session, {
 			currentDate: new Date('2050-08-06T12:00:00.000Z'),
 		});
 
-		const request = await context.dequeue();
+		const request = await ctx.dequeue();
 		assert(request !== null);
 		const requestDate = new Date(request.data.timestamp);
 		expect(requestDate.getTime() < Date.now()).toBe(false);
 	});
 
 	it('should enqueue two actions if there are two time triggers with a past start dates', async () => {
-		const actionCard = await context.jellyfish.getCardBySlug(
-			context.context,
-			context.session,
+		const actionCard = await ctx.jellyfish.getCardBySlug(
+			ctx.context,
+			ctx.session,
 			'action-create-card@latest',
 		);
 
 		assert(actionCard !== null);
 
-		const slug1 = context.generateRandomSlug();
-		const slug2 = context.generateRandomSlug();
-		context.worker.setTriggers(context.context, [
-			{
+		const slug1 = ctx.generateRandomSlug();
+		const slug2 = ctx.generateRandomSlug();
+		ctx.worker.setTriggers(ctx.context, [
+			ctx.jellyfish.defaults({
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
-				action: `${actionCard.slug}@${actionCard.version}`,
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				interval: 'PT1D',
-				startDate: '2018-08-05T12:00:00.000Z',
-				arguments: {
-					reason: null,
-					properties: {
-						version: '1.0.0',
-						slug: slug1,
+				type: 'triggered-action@1.0.0',
+				data: {
+					action: `${actionCard.slug}@${actionCard.version}`,
+					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+					interval: 'PT1D',
+					startDate: '2018-08-05T12:00:00.000Z',
+					arguments: {
+						reason: null,
+						properties: {
+							version: '1.0.0',
+							slug: slug1,
+						},
 					},
 				},
-			},
-			{
+			}) as TriggeredActionContract,
+			ctx.jellyfish.defaults({
 				id: '673bc300-88f7-4376-92ed-d32543d69429',
 				slug: 'triggered-action-foo-baz',
-				action: `${actionCard.slug}@${actionCard.version}`,
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				interval: 'PT2D',
-				startDate: '2018-08-04T12:00:00.000Z',
-				arguments: {
-					reason: null,
-					properties: {
-						version: '1.0.0',
-						slug: slug2,
+				type: 'triggered-action@1.0.0',
+				data: {
+					action: `${actionCard.slug}@${actionCard.version}`,
+					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+					interval: 'PT2D',
+					startDate: '2018-08-04T12:00:00.000Z',
+					arguments: {
+						reason: null,
+						properties: {
+							version: '1.0.0',
+							slug: slug2,
+						},
 					},
 				},
-			},
+			}) as TriggeredActionContract,
 		]);
 
-		await context.worker.tick(context.context, context.session, {
+		await ctx.worker.tick(ctx.context, ctx.session, {
 			currentDate: new Date('2018-08-06T12:00:00.000Z'),
 		});
 
 		const actionRequests = _.sortBy(
-			await context.jellyfish.query(context.context, context.session, {
+			await ctx.jellyfish.query(ctx.context, ctx.session, {
 				type: 'object',
 				required: ['type'],
 				additionalProperties: true,
@@ -359,7 +384,7 @@ describe('.tick()', () => {
 		);
 
 		expect(actionRequests).toEqual([
-			context.jellyfish.defaults({
+			ctx.jellyfish.defaults({
 				id: actionRequests[0].id,
 				slug: actionRequests[0].slug,
 				name: null,
@@ -370,9 +395,9 @@ describe('.tick()', () => {
 					input: {
 						id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 					},
-					context: context.context,
+					context: ctx.context,
 					action: `${actionCard.slug}@${actionCard.version}`,
-					actor: context.actor.id,
+					actor: ctx.actor.id,
 					originator: '673bc300-88f7-4376-92ed-d32543d69429',
 					timestamp: '2018-08-06T12:00:00.000Z',
 					epoch: 1533556800000,
@@ -385,7 +410,7 @@ describe('.tick()', () => {
 					},
 				},
 			}),
-			context.jellyfish.defaults({
+			ctx.jellyfish.defaults({
 				id: actionRequests[1].id,
 				slug: actionRequests[1].slug,
 				name: null,
@@ -396,9 +421,9 @@ describe('.tick()', () => {
 					input: {
 						id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 					},
-					context: context.context,
+					context: ctx.context,
 					action: `${actionCard.slug}@${actionCard.version}`,
-					actor: context.actor.id,
+					actor: ctx.actor.id,
 					originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 					timestamp: '2018-08-06T12:00:00.000Z',
 					epoch: 1533556800000,

--- a/test/integration/trigger-updates.spec.ts
+++ b/test/integration/trigger-updates.spec.ts
@@ -4,90 +4,26 @@
  * Proprietary and confidential.
  */
 
+import { TriggeredActionContract } from '@balena/jellyfish-types/build/worker';
 import * as helpers from './helpers';
 
-let context: helpers.IntegrationTestContext;
+let ctx: helpers.IntegrationTestContext;
 
 beforeAll(async () => {
-	context = await helpers.before();
+	ctx = await helpers.before();
 });
 
 afterAll(() => {
-	return helpers.after(context);
+	return helpers.after(ctx);
 });
 
 describe('.setTriggers()', () => {
-	it('should be able to set a trigger with a start date', () => {
-		context.worker.setTriggers(context.context, [
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
-				action: 'action-foo-bar@1.0.0',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				startDate: '2008-01-01T00:00:00.000Z',
-				filter: {
-					type: 'object',
-				},
-				arguments: {
-					foo: 'bar',
-				},
-			},
-		]);
-
-		const triggers = context.worker.getTriggers();
-
-		expect(triggers).toEqual([
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
-				action: 'action-foo-bar@1.0.0',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				startDate: '2008-01-01T00:00:00.000Z',
-				filter: {
-					type: 'object',
-				},
-				arguments: {
-					foo: 'bar',
-				},
-			},
-		]);
-	});
-
-	it('should be able to set a trigger with an interval', () => {
-		context.worker.setTriggers(context.context, [
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
-				action: 'action-foo-bar@1.0.0',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				interval: 'PT1H',
-				arguments: {
-					foo: 'bar',
-				},
-			},
-		]);
-
-		const triggers = context.worker.getTriggers();
-
-		expect(triggers).toEqual([
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
-				action: 'action-foo-bar@1.0.0',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				interval: 'PT1H',
-				arguments: {
-					foo: 'bar',
-				},
-			},
-		]);
-	});
-
 	it('should be able to set triggers', () => {
-		context.worker.setTriggers(context.context, [
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
+		const trigger1 = ctx.jellyfish.defaults({
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
+			type: 'triggered-action@1.0.0',
+			data: {
 				action: 'action-foo-bar@1.0.0',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				filter: {
@@ -97,9 +33,13 @@ describe('.setTriggers()', () => {
 					foo: 'bar',
 				},
 			},
-			{
-				id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
-				slug: 'triggered-action-foo-baz',
+		}) as TriggeredActionContract;
+
+		const trigger2 = ctx.jellyfish.defaults({
+			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+			slug: 'triggered-action-foo-baz',
+			type: 'triggered-action@1.0.0',
+			data: {
 				action: 'action-foo-bar@1.0.0',
 				target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
 				filter: {
@@ -109,395 +49,23 @@ describe('.setTriggers()', () => {
 					foo: 'baz',
 				},
 			},
-		]);
+		}) as TriggeredActionContract;
 
-		const triggers = context.worker.getTriggers();
+		ctx.worker.setTriggers(ctx.context, [trigger1, trigger2]);
 
-		expect(triggers).toEqual([
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
-				action: 'action-foo-bar@1.0.0',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				filter: {
-					type: 'object',
-				},
-				arguments: {
-					foo: 'bar',
-				},
-			},
-			{
-				id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
-				slug: 'triggered-action-foo-baz',
-				action: 'action-foo-bar@1.0.0',
-				target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
-				filter: {
-					type: 'object',
-				},
-				arguments: {
-					foo: 'baz',
-				},
-			},
-		]);
-	});
+		const triggers = ctx.worker.getTriggers();
 
-	it('should not store extra properties', () => {
-		context.worker.setTriggers(context.context, [
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
-				foo: 'bar',
-				bar: 'baz',
-				action: 'action-foo-bar@1.0.0',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				filter: {
-					type: 'object',
-				},
-				arguments: {
-					foo: 'bar',
-				},
-			} as any,
-		]);
-
-		const triggers = context.worker.getTriggers();
-
-		expect(triggers).toEqual([
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
-				action: 'action-foo-bar@1.0.0',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				filter: {
-					type: 'object',
-				},
-				arguments: {
-					foo: 'bar',
-				},
-			},
-		]);
-	});
-
-	it('should store a mode', () => {
-		context.worker.setTriggers(context.context, [
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
-				mode: 'update',
-				action: 'action-foo-bar@1.0.0',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				filter: {
-					type: 'object',
-				},
-				arguments: {
-					foo: 'bar',
-				},
-			},
-		]);
-
-		const triggers = context.worker.getTriggers();
-
-		expect(triggers).toEqual([
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
-				action: 'action-foo-bar@1.0.0',
-				mode: 'update',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				filter: {
-					type: 'object',
-				},
-				arguments: {
-					foo: 'bar',
-				},
-			},
-		]);
-	});
-
-	it('should throw if no interval nor filter', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-					slug: 'triggered-action-foo-bar',
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					action: 'action-create-card@1.0.0',
-					arguments: {
-						reason: null,
-						foo: 'bar',
-					},
-				},
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if mode is not a string', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-					slug: 'triggered-action-foo-bar',
-					action: 'action-foo-bar@1.0.0',
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					mode: 1,
-					filter: {
-						type: 'object',
-					},
-					arguments: {
-						foo: 'bar',
-					},
-				},
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if both interval and filter', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-					slug: 'triggered-action-foo-bar',
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					interval: 'PT1H',
-					filter: {
-						type: 'object',
-					},
-					action: 'action-create-card@1.0.0',
-					arguments: {
-						reason: null,
-						foo: 'bar',
-					},
-				},
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if no id', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					slug: 'triggered-action-foo-bar',
-					action: 'action-create-card@1.0.0',
-					filter: {
-						type: 'object',
-					},
-					arguments: {
-						reason: null,
-						foo: 'bar',
-					},
-				} as any,
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if no slug', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					action: 'action-create-card@1.0.0',
-					filter: {
-						type: 'object',
-					},
-					arguments: {
-						reason: null,
-						foo: 'bar',
-					},
-				} as any,
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if id is not a string', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 999,
-					slug: 'triggered-action-foo-bar',
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					action: 'action-create-card@1.0.0',
-					filter: {
-						type: 'object',
-					},
-					arguments: {
-						reason: null,
-						foo: 'bar',
-					},
-				} as any,
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if interval is not a string', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-					slug: 'triggered-action-foo-bar',
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					action: 'action-create-card@1.0.0',
-					interval: 999,
-					arguments: {
-						reason: null,
-						foo: 'bar',
-					},
-				},
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if no action', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-					slug: 'triggered-action-foo-bar',
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					filter: {
-						type: 'object',
-					},
-					arguments: {
-						foo: 'bar',
-					},
-				} as any,
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if action is not a string', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-					slug: 'triggered-action-foo-bar',
-					action: 1,
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					filter: {
-						type: 'object',
-					},
-					arguments: {
-						foo: 'bar',
-					},
-				},
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if no target', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-					slug: 'triggered-action-foo-bar',
-					action: 'action-create-card@1.0.0',
-					filter: {
-						type: 'object',
-					},
-					arguments: {
-						reason: null,
-						foo: 'bar',
-					},
-				} as any,
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if target is not a string', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-					slug: 'triggered-action-foo-bar',
-					action: 'action-create-card@1.0.0',
-					target: 1,
-					filter: {
-						type: 'object',
-					},
-					arguments: {
-						reason: null,
-						foo: 'bar',
-					},
-				},
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if no filter', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-					slug: 'triggered-action-foo-bar',
-					action: 'action-create-card@1.0.0',
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					arguments: {
-						reason: null,
-						foo: 'bar',
-					},
-				},
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if filter is not an object', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-					slug: 'triggered-action-foo-bar',
-					action: 'action-create-card@1.0.0',
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					filter: 'foo',
-					arguments: {
-						reason: null,
-						foo: 'bar',
-					},
-				},
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if no arguments', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-					slug: 'triggered-action-foo-bar',
-					action: 'action-create-card@1.0.0',
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					filter: {
-						type: 'object',
-					},
-				} as any,
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
-	});
-
-	it('should throw if arguments is not an object', () => {
-		expect(() => {
-			context.worker.setTriggers(context.context, [
-				{
-					id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-					slug: 'triggered-action-foo-bar',
-					action: 'action-create-card@1.0.0',
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-					filter: {
-						type: 'object',
-					},
-					arguments: 1,
-				},
-			]);
-		}).toThrow(context.worker.errors.WorkerInvalidTrigger);
+		expect(triggers).toEqual([trigger1, trigger2]);
 	});
 });
 
 describe('.upsertTrigger()', () => {
 	it('should be able to add a trigger', () => {
-		context.worker.setTriggers(context.context, [
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
+		const trigger1 = ctx.jellyfish.defaults({
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
+			type: 'triggered-action@1.0.0',
+			data: {
 				action: 'action-foo-bar@1.0.0',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				filter: {
@@ -507,39 +75,13 @@ describe('.upsertTrigger()', () => {
 					foo: 'bar',
 				},
 			},
-		]);
+		}) as TriggeredActionContract;
 
-		context.worker.upsertTrigger(context.context, {
+		const trigger2 = ctx.jellyfish.defaults({
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
-			action: 'action-foo-bar@1.0.0',
-			target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
-			filter: {
-				type: 'object',
-			},
-			arguments: {
-				foo: 'baz',
-			},
-		});
-
-		const triggers = context.worker.getTriggers();
-
-		expect(triggers).toEqual([
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
-				action: 'action-foo-bar@1.0.0',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				filter: {
-					type: 'object',
-				},
-				arguments: {
-					foo: 'bar',
-				},
-			},
-			{
-				id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
-				slug: 'triggered-action-foo-baz',
+			type: 'triggered-action@1.0.0',
+			data: {
 				action: 'action-foo-bar@1.0.0',
 				target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
 				filter: {
@@ -549,14 +91,23 @@ describe('.upsertTrigger()', () => {
 					foo: 'baz',
 				},
 			},
-		]);
+		}) as TriggeredActionContract;
+
+		ctx.worker.setTriggers(ctx.context, [trigger1]);
+
+		ctx.worker.upsertTrigger(ctx.context, trigger2);
+
+		const triggers = ctx.worker.getTriggers();
+
+		expect(triggers).toEqual([trigger1, trigger2]);
 	});
 
 	it('should be able to modify an existing trigger', () => {
-		context.worker.setTriggers(context.context, [
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
+		const trigger1 = ctx.jellyfish.defaults({
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
+			type: 'triggered-action@1.0.0',
+			data: {
 				action: 'action-foo-bar@1.0.0',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				filter: {
@@ -566,9 +117,13 @@ describe('.upsertTrigger()', () => {
 					foo: 'bar',
 				},
 			},
-			{
-				id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
-				slug: 'triggered-action-foo-baz',
+		}) as TriggeredActionContract;
+
+		const trigger2 = ctx.jellyfish.defaults({
+			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+			slug: 'triggered-action-foo-baz',
+			type: 'triggered-action@1.0.0',
+			data: {
 				action: 'action-foo-bar@1.0.0',
 				target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
 				filter: {
@@ -578,46 +133,31 @@ describe('.upsertTrigger()', () => {
 					foo: 'baz',
 				},
 			},
-		]);
+		}) as TriggeredActionContract;
 
-		context.worker.upsertTrigger(context.context, {
-			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
-			slug: 'triggered-action-foo-baz',
-			action: 'action-foo-bar@1.0.0',
-			target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
-			filter: {
-				type: 'object',
-			},
-			arguments: {
-				baz: 'buzz',
+		ctx.worker.setTriggers(ctx.context, [trigger1, trigger2]);
+
+		const newArguments = {
+			baz: 'buzz',
+		};
+
+		ctx.worker.upsertTrigger(ctx.context, {
+			...trigger2,
+			data: {
+				...trigger2.data,
+				arguments: newArguments,
 			},
 		});
 
-		const triggers = context.worker.getTriggers();
+		const triggers = ctx.worker.getTriggers();
 
 		expect(triggers).toEqual([
+			trigger1,
 			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
-				action: 'action-foo-bar@1.0.0',
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
-				filter: {
-					type: 'object',
-				},
-				arguments: {
-					foo: 'bar',
-				},
-			},
-			{
-				id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
-				slug: 'triggered-action-foo-baz',
-				action: 'action-foo-bar@1.0.0',
-				target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
-				filter: {
-					type: 'object',
-				},
-				arguments: {
-					baz: 'buzz',
+				...trigger2,
+				data: {
+					...trigger2.data,
+					arguments: newArguments,
 				},
 			},
 		]);
@@ -626,10 +166,11 @@ describe('.upsertTrigger()', () => {
 
 describe('.removeTrigger()', () => {
 	it('should be able to remove an existing trigger', () => {
-		const cards = [
-			{
-				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-				slug: 'triggered-action-foo-bar',
+		const trigger1 = ctx.jellyfish.defaults({
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
+			type: 'triggered-action@1.0.0',
+			data: {
 				action: 'action-foo-bar@1.0.0',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				filter: {
@@ -639,12 +180,15 @@ describe('.removeTrigger()', () => {
 					foo: 'bar',
 				},
 			},
-			{
-				id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
-				slug: 'triggered-action-foo-baz',
+		}) as TriggeredActionContract;
+
+		const trigger2 = ctx.jellyfish.defaults({
+			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+			slug: 'triggered-action-foo-baz',
+			type: 'triggered-action@1.0.0',
+			data: {
 				action: 'action-foo-bar@1.0.0',
 				target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
-				type: 'card@1.0.0',
 				filter: {
 					type: 'object',
 				},
@@ -652,14 +196,14 @@ describe('.removeTrigger()', () => {
 					foo: 'baz',
 				},
 			},
-		];
+		}) as TriggeredActionContract;
 
-		context.worker.setTriggers(context.context, cards);
+		ctx.worker.setTriggers(ctx.context, [trigger1, trigger2]);
 
-		context.worker.removeTrigger(context.context, cards[1].id);
+		ctx.worker.removeTrigger(ctx.context, trigger1.id);
 
-		const triggers = context.worker.getTriggers();
+		const triggers = ctx.worker.getTriggers();
 
-		expect(triggers).toEqual([cards[0]]);
+		expect(triggers).toEqual([trigger2]);
 	});
 });

--- a/test/integration/triggers.spec.ts
+++ b/test/integration/triggers.spec.ts
@@ -10,6 +10,7 @@ import { strict as assert } from 'assert';
 import * as helpers from './helpers';
 import { triggers, errors } from '../../lib/index';
 import { Contract, TypeContract } from '@balena/jellyfish-types/build/core';
+import { TriggeredActionContract } from '@balena/jellyfish-types/build/worker';
 
 let ctx: helpers.IntegrationTestContext;
 let typeCard: TypeContract;
@@ -73,26 +74,29 @@ afterAll(() => {
 
 describe('.getRequest()', () => {
 	it('should return null if the filter only has a type but there is no match', async () => {
-		const trigger = {
-			mode: 'insert',
-			filter: {
-				type: 'object',
-				required: ['type'],
-				properties: {
-					type: {
-						type: 'string',
-						const: 'foo@1.0.0',
+		const trigger = ctx.jellyfish.defaults({
+			type: 'triggered-action@1.0.0',
+			data: {
+				mode: 'insert',
+				filter: {
+					type: 'object',
+					required: ['type'],
+					properties: {
+						type: {
+							type: 'string',
+							const: 'foo@1.0.0',
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				card: typeCard.id,
+				arguments: {
+					properties: {
+						slug: 'foo-bar-baz',
 					},
 				},
 			},
-			action: 'action-create-card@1.0.0',
-			card: typeCard.id,
-			arguments: {
-				properties: {
-					slug: 'foo-bar-baz',
-				},
-			},
-		};
+		}) as TriggeredActionContract;
 
 		const insertedCard = await ctx.jellyfish.insertCard(
 			ctx.context,
@@ -112,7 +116,7 @@ describe('.getRequest()', () => {
 		// TS-TODO: fix cast to any
 		const request = await triggers.getRequest(
 			ctx.jellyfish,
-			trigger as any,
+			trigger,
 			insertedCard,
 			{
 				currentDate: new Date(),
@@ -126,27 +130,30 @@ describe('.getRequest()', () => {
 	});
 
 	it('should return a request if the filter only has a type and there is a match', async () => {
-		const trigger = {
+		const trigger = ctx.jellyfish.defaults({
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			mode: 'insert',
-			filter: {
-				type: 'object',
-				required: ['type'],
-				properties: {
-					type: {
-						type: 'string',
-						const: 'foo@1.0.0',
+			type: 'triggered-action@1.0.0',
+			data: {
+				mode: 'insert',
+				filter: {
+					type: 'object',
+					required: ['type'],
+					properties: {
+						type: {
+							type: 'string',
+							const: 'foo@1.0.0',
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					properties: {
+						slug: 'foo-bar-baz',
 					},
 				},
 			},
-			action: 'action-create-card@1.0.0',
-			target: typeCard.id,
-			arguments: {
-				properties: {
-					slug: 'foo-bar-baz',
-				},
-			},
-		};
+		}) as TriggeredActionContract;
 
 		const date = new Date();
 
@@ -192,27 +199,30 @@ describe('.getRequest()', () => {
 	});
 
 	it('should return a request if the input card is null', async () => {
-		const trigger = {
+		const trigger = ctx.jellyfish.defaults({
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			mode: 'insert',
-			filter: {
-				type: 'object',
-				required: ['type'],
-				properties: {
-					type: {
-						type: 'string',
-						const: 'foo@1.0.0',
+			type: 'triggered-action@1.0.0',
+			data: {
+				mode: 'insert',
+				filter: {
+					type: 'object',
+					required: ['type'],
+					properties: {
+						type: {
+							type: 'string',
+							const: 'foo@1.0.0',
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					properties: {
+						slug: 'foo-bar-baz',
 					},
 				},
 			},
-			action: 'action-create-card@1.0.0',
-			target: typeCard.id,
-			arguments: {
-				properties: {
-					slug: 'foo-bar-baz',
-				},
-			},
-		};
+		}) as TriggeredActionContract;
 
 		const date = new Date();
 
@@ -238,29 +248,32 @@ describe('.getRequest()', () => {
 	});
 
 	it('should return null if referencing source when no input card', async () => {
-		const trigger = {
+		const trigger = ctx.jellyfish.defaults({
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			mode: 'insert',
-			filter: {
-				type: 'object',
-				required: ['type'],
-				properties: {
-					type: {
-						type: 'string',
-						const: 'foo@1.0.0',
+			type: 'triggered-action@1.0.0',
+			data: {
+				mode: 'insert',
+				filter: {
+					type: 'object',
+					required: ['type'],
+					properties: {
+						type: {
+							type: 'string',
+							const: 'foo@1.0.0',
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					properties: {
+						slug: {
+							$eval: 'source.type',
+						},
 					},
 				},
 			},
-			action: 'action-create-card@1.0.0',
-			target: typeCard.id,
-			arguments: {
-				properties: {
-					slug: {
-						$eval: 'source.type',
-					},
-				},
-			},
-		};
+		}) as TriggeredActionContract;
 
 		const request = await triggers.getRequest(ctx.jellyfish, trigger, null, {
 			currentDate: new Date(),
@@ -273,36 +286,39 @@ describe('.getRequest()', () => {
 	});
 
 	it('should return a request given a complex matching filter', async () => {
-		const trigger = {
+		const trigger = ctx.jellyfish.defaults({
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			mode: 'insert',
-			filter: {
-				type: 'object',
-				required: ['type', 'data'],
-				properties: {
-					type: {
-						type: 'string',
-						const: 'foo@1.0.0',
-					},
-					data: {
-						type: 'object',
-						required: ['foo'],
-						properties: {
-							foo: {
-								type: 'number',
+			type: 'triggered-action@1.0.0',
+			data: {
+				mode: 'insert',
+				filter: {
+					type: 'object',
+					required: ['type', 'data'],
+					properties: {
+						type: {
+							type: 'string',
+							const: 'foo@1.0.0',
+						},
+						data: {
+							type: 'object',
+							required: ['foo'],
+							properties: {
+								foo: {
+									type: 'number',
+								},
 							},
 						},
 					},
 				},
-			},
-			action: 'action-create-card@1.0.0',
-			target: typeCard.id,
-			arguments: {
-				properties: {
-					slug: 'foo-bar-baz',
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					properties: {
+						slug: 'foo-bar-baz',
+					},
 				},
 			},
-		};
+		}) as TriggeredActionContract;
 
 		const date = new Date();
 
@@ -350,35 +366,38 @@ describe('.getRequest()', () => {
 	});
 
 	it('should return null given a complex non-matching filter', async () => {
-		const trigger = {
-			mode: 'insert',
-			filter: {
-				type: 'object',
-				required: ['type', 'data'],
-				properties: {
-					type: {
-						type: 'string',
-						const: 'foo@1.0.0',
-					},
-					data: {
-						type: 'object',
-						required: ['foo'],
-						properties: {
-							foo: {
-								type: 'number',
+		const trigger = ctx.jellyfish.defaults({
+			type: 'triggered-action@1.0.0',
+			data: {
+				mode: 'insert',
+				filter: {
+					type: 'object',
+					required: ['type', 'data'],
+					properties: {
+						type: {
+							type: 'string',
+							const: 'foo@1.0.0',
+						},
+						data: {
+							type: 'object',
+							required: ['foo'],
+							properties: {
+								foo: {
+									type: 'number',
+								},
 							},
 						},
 					},
 				},
-			},
-			action: 'action-create-card@1.0.0',
-			target: typeCard.id,
-			arguments: {
-				properties: {
-					slug: 'foo-bar-baz',
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					properties: {
+						slug: 'foo-bar-baz',
+					},
 				},
 			},
-		};
+		}) as TriggeredActionContract;
 
 		const insertedCard = await ctx.jellyfish.insertCard(
 			ctx.context,
@@ -400,7 +419,7 @@ describe('.getRequest()', () => {
 		// TS-TODO: fix cast to any
 		const request = await triggers.getRequest(
 			ctx.jellyfish,
-			trigger as any,
+			trigger,
 			insertedCard,
 			{
 				currentDate: new Date(),
@@ -414,40 +433,43 @@ describe('.getRequest()', () => {
 	});
 
 	it('should parse source templates in the triggered action arguments', async () => {
-		const trigger = {
+		const trigger = ctx.jellyfish.defaults({
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			mode: 'insert',
-			filter: {
-				type: 'object',
-				required: ['data'],
-				properties: {
-					data: {
-						type: 'object',
-						required: ['command'],
-						properties: {
-							command: {
-								type: 'string',
-								const: 'foo-bar-baz',
+			type: 'triggered-action@1.0.0',
+			data: {
+				mode: 'insert',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: 'foo-bar-baz',
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					properties: {
+						slug: {
+							$eval: 'source.data.slug',
+						},
+						data: {
+							number: {
+								$eval: 'source.data.number',
 							},
 						},
 					},
 				},
 			},
-			action: 'action-create-card@1.0.0',
-			target: typeCard.id,
-			arguments: {
-				properties: {
-					slug: {
-						$eval: 'source.data.slug',
-					},
-					data: {
-						number: {
-							$eval: 'source.data.number',
-						},
-					},
-				},
-			},
-		};
+		}) as TriggeredActionContract;
 
 		const date = new Date();
 
@@ -500,40 +522,43 @@ describe('.getRequest()', () => {
 	});
 
 	it('should return the request if the mode matches on update', async () => {
-		const trigger = {
+		const trigger = ctx.jellyfish.defaults({
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			filter: {
-				type: 'object',
-				required: ['data'],
-				properties: {
-					data: {
-						type: 'object',
-						required: ['command'],
-						properties: {
-							command: {
-								type: 'string',
-								const: 'foo-bar-baz',
+			type: 'triggered-action@1.0.0',
+			data: {
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: 'foo-bar-baz',
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				mode: 'update',
+				arguments: {
+					properties: {
+						slug: {
+							$eval: 'source.data.slug',
+						},
+						data: {
+							number: {
+								$eval: 'source.data.number',
 							},
 						},
 					},
 				},
 			},
-			action: 'action-create-card@1.0.0',
-			target: typeCard.id,
-			mode: 'update',
-			arguments: {
-				properties: {
-					slug: {
-						$eval: 'source.data.slug',
-					},
-					data: {
-						number: {
-							$eval: 'source.data.number',
-						},
-					},
-				},
-			},
-		};
+		}) as TriggeredActionContract;
 
 		const date = new Date();
 
@@ -586,40 +611,43 @@ describe('.getRequest()', () => {
 	});
 
 	it('should return the request if the mode matches on insert', async () => {
-		const trigger = {
+		const trigger = ctx.jellyfish.defaults({
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			filter: {
-				type: 'object',
-				required: ['data'],
-				properties: {
-					data: {
-						type: 'object',
-						required: ['command'],
-						properties: {
-							command: {
-								type: 'string',
-								const: 'foo-bar-baz',
+			type: 'triggered-action@1.0.0',
+			data: {
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: 'foo-bar-baz',
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				mode: 'insert',
+				arguments: {
+					properties: {
+						slug: {
+							$eval: 'source.data.slug',
+						},
+						data: {
+							number: {
+								$eval: 'source.data.number',
 							},
 						},
 					},
 				},
 			},
-			action: 'action-create-card@1.0.0',
-			target: typeCard.id,
-			mode: 'insert',
-			arguments: {
-				properties: {
-					slug: {
-						$eval: 'source.data.slug',
-					},
-					data: {
-						number: {
-							$eval: 'source.data.number',
-						},
-					},
-				},
-			},
-		};
+		}) as TriggeredActionContract;
 
 		const date = new Date();
 
@@ -672,40 +700,43 @@ describe('.getRequest()', () => {
 	});
 
 	it('should return null if the mode does not match', async () => {
-		const trigger = {
+		const trigger = ctx.jellyfish.defaults({
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			filter: {
-				type: 'object',
-				required: ['data'],
-				properties: {
-					data: {
-						type: 'object',
-						required: ['command'],
-						properties: {
-							command: {
-								type: 'string',
-								const: 'foo-bar-baz',
+			type: 'triggered-action@1.0.0',
+			data: {
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: 'foo-bar-baz',
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				mode: 'update',
+				arguments: {
+					properties: {
+						slug: {
+							$eval: 'source.data.slug',
+						},
+						data: {
+							number: {
+								$eval: 'source.data.number',
 							},
 						},
 					},
 				},
 			},
-			action: 'action-create-card@1.0.0',
-			target: typeCard.id,
-			mode: 'update',
-			arguments: {
-				properties: {
-					slug: {
-						$eval: 'source.data.slug',
-					},
-					data: {
-						number: {
-							$eval: 'source.data.number',
-						},
-					},
-				},
-			},
-		};
+		}) as TriggeredActionContract;
 
 		const date = new Date();
 
@@ -744,24 +775,27 @@ describe('.getRequest()', () => {
 	});
 
 	it('should parse timestamp templates in the triggered action arguments', async () => {
-		const trigger = {
+		const trigger = ctx.jellyfish.defaults({
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			mode: 'insert',
-			filter: {
-				type: 'object',
-			},
-			action: 'action-create-card@1.0.0',
-			target: typeCard.id,
-			arguments: {
-				properties: {
-					data: {
-						timestamp: {
-							$eval: 'timestamp',
+			type: 'triggered-action@1.0.0',
+			data: {
+				mode: 'insert',
+				filter: {
+					type: 'object',
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					properties: {
+						data: {
+							timestamp: {
+								$eval: 'timestamp',
+							},
 						},
 					},
 				},
 			},
-		};
+		}) as TriggeredActionContract;
 
 		const currentDate = new Date();
 
@@ -813,39 +847,44 @@ describe('.getRequest()', () => {
 	});
 
 	it('should return null if one of the templates is unsatisfied', async () => {
-		const trigger = {
-			mode: 'insert',
-			filter: {
-				type: 'object',
-				required: ['data'],
-				properties: {
-					data: {
-						type: 'object',
-						required: ['command'],
-						properties: {
-							command: {
-								type: 'string',
-								const: 'foo-bar-baz',
+		const trigger = ctx.jellyfish.defaults({
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-cb3523c5',
+			type: 'triggered-action@1.0.0',
+			data: {
+				mode: 'insert',
+				filter: {
+					type: 'object',
+					required: ['data'],
+					properties: {
+						data: {
+							type: 'object',
+							required: ['command'],
+							properties: {
+								command: {
+									type: 'string',
+									const: 'foo-bar-baz',
+								},
+							},
+						},
+					},
+				},
+				action: 'action-create-card@1.0.0',
+				target: typeCard.id,
+				arguments: {
+					properties: {
+						slug: {
+							$eval: 'source.data.slug',
+						},
+						data: {
+							number: {
+								$eval: 'source.data.number',
 							},
 						},
 					},
 				},
 			},
-			action: 'action-create-card@1.0.0',
-			target: typeCard.id,
-			arguments: {
-				properties: {
-					slug: {
-						$eval: 'source.data.slug',
-					},
-					data: {
-						number: {
-							$eval: 'source.data.number',
-						},
-					},
-				},
-			},
-		};
+		}) as TriggeredActionContract;
 
 		const insertedCard = await ctx.jellyfish.insertCard(
 			ctx.context,
@@ -867,7 +906,7 @@ describe('.getRequest()', () => {
 
 		const request = await triggers.getRequest(
 			ctx.jellyfish,
-			trigger as any,
+			trigger,
 			insertedCard,
 			{
 				currentDate: new Date(),
@@ -1308,102 +1347,8 @@ describe('.getTypeTriggers()', () => {
 describe('.getStartDate()', () => {
 	it('should return epoch if the trigger has no start date', async () => {
 		// TS-TODO: remove the cast to "any"
-		const result = triggers.getStartDate({
-			type: 'triggered-action@1.0.0',
-			slug: ctx.generateRandomSlug({
-				prefix: 'triggered-action',
-			}),
-			version: '1.0.0',
-			active: true,
-			links: {},
-			tags: [],
-			markers: [],
-			data: {
-				filter: {
-					type: 'object',
-				},
-				action: 'action-create-card@1.0.0',
-				target: typeCard.id,
-				arguments: {
-					properties: {
-						slug: 'foo',
-					},
-				},
-			},
-		} as any);
-
-		expect(result.getTime()).toBe(0);
-	});
-
-	it('should return epoch if the trigger has an invalid date', async () => {
-		// TS-TODO: remove the cast to "any"
-		const result = triggers.getStartDate({
-			type: 'triggered-action@1.0.0',
-			slug: ctx.generateRandomSlug({
-				prefix: 'triggered-action',
-			}),
-			version: '1.0.0',
-			active: true,
-			links: {},
-			tags: [],
-			markers: [],
-			data: {
-				filter: {
-					type: 'object',
-				},
-				startDate: 'foo',
-				action: 'action-create-card@1.0.0',
-				target: typeCard.id,
-				arguments: {
-					properties: {
-						slug: 'foo',
-					},
-				},
-			},
-		} as any);
-
-		expect(result.getTime()).toBe(0);
-	});
-
-	it('should return the specified date if valid', async () => {
-		const date = new Date();
-		// TS-TODO: Remove the cast to "any"
-		const result = triggers.getStartDate({
-			type: 'triggered-action@1.0.0',
-			slug: ctx.generateRandomSlug({
-				prefix: 'triggered-action',
-			}),
-			version: '1.0.0',
-			active: true,
-			links: {},
-			tags: [],
-			markers: [],
-			data: {
-				filter: {
-					type: 'object',
-				},
-				startDate: date.toISOString(),
-				action: 'action-create-card@1.0.0',
-				target: typeCard.id,
-				arguments: {
-					properties: {
-						slug: 'foo',
-					},
-				},
-			},
-		} as any);
-
-		expect(result.getTime()).toBe(date.getTime());
-	});
-});
-
-describe('.getNextExecutionDate()', () => {
-	it('should return null if no interval', async () => {
-		const date = new Date();
-
-		// TS-TODO: fix the cast to any here
-		const result = triggers.getNextExecutionDate(
-			{
+		const result = triggers.getStartDate(
+			ctx.jellyfish.defaults({
 				type: 'triggered-action@1.0.0',
 				slug: ctx.generateRandomSlug({
 					prefix: 'triggered-action',
@@ -1425,7 +1370,107 @@ describe('.getNextExecutionDate()', () => {
 						},
 					},
 				},
-			} as any,
+			}) as TriggeredActionContract,
+		);
+
+		expect(result.getTime()).toBe(0);
+	});
+
+	it('should return epoch if the trigger has an invalid date', async () => {
+		// TS-TODO: remove the cast to "any"
+		const result = triggers.getStartDate(
+			ctx.jellyfish.defaults({
+				type: 'triggered-action@1.0.0',
+				slug: ctx.generateRandomSlug({
+					prefix: 'triggered-action',
+				}),
+				version: '1.0.0',
+				active: true,
+				links: {},
+				tags: [],
+				markers: [],
+				data: {
+					filter: {
+						type: 'object',
+					},
+					startDate: 'foo',
+					action: 'action-create-card@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						properties: {
+							slug: 'foo',
+						},
+					},
+				},
+			}) as TriggeredActionContract,
+		);
+
+		expect(result.getTime()).toBe(0);
+	});
+
+	it('should return the specified date if valid', async () => {
+		const date = new Date();
+		// TS-TODO: Remove the cast to "any"
+		const result = triggers.getStartDate(
+			ctx.jellyfish.defaults({
+				type: 'triggered-action@1.0.0',
+				slug: ctx.generateRandomSlug({
+					prefix: 'triggered-action',
+				}),
+				version: '1.0.0',
+				active: true,
+				links: {},
+				tags: [],
+				markers: [],
+				data: {
+					filter: {
+						type: 'object',
+					},
+					startDate: date.toISOString(),
+					action: 'action-create-card@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						properties: {
+							slug: 'foo',
+						},
+					},
+				},
+			}) as TriggeredActionContract,
+		);
+
+		expect(result.getTime()).toBe(date.getTime());
+	});
+});
+
+describe('.getNextExecutionDate()', () => {
+	it('should return null if no interval', async () => {
+		const date = new Date();
+
+		// TS-TODO: fix the cast to any here
+		const result = triggers.getNextExecutionDate(
+			ctx.jellyfish.defaults({
+				type: 'triggered-action@1.0.0',
+				slug: ctx.generateRandomSlug({
+					prefix: 'triggered-action',
+				}),
+				version: '1.0.0',
+				active: true,
+				links: {},
+				tags: [],
+				markers: [],
+				data: {
+					filter: {
+						type: 'object',
+					},
+					action: 'action-create-card@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						properties: {
+							slug: 'foo',
+						},
+					},
+				},
+			}) as TriggeredActionContract,
 			date,
 		);
 
@@ -1434,35 +1479,8 @@ describe('.getNextExecutionDate()', () => {
 
 	it('should return epoch if no last execution date', async () => {
 		// TS-TODO: fix the cast to any here
-		const result = triggers.getNextExecutionDate({
-			type: 'triggered-action@1.0.0',
-			slug: ctx.generateRandomSlug({
-				prefix: 'triggered-action',
-			}),
-			version: '1.0.0',
-			active: true,
-			links: {},
-			tags: [],
-			markers: [],
-			data: {
-				interval: 'PT1H',
-				action: 'action-create-card@1.0.0',
-				target: typeCard.id,
-				arguments: {
-					properties: {
-						slug: 'foo',
-					},
-				},
-			},
-		} as any);
-
-		expect(result!.getTime()).toBe(0);
-	});
-
-	it('should return epoch if last execution date is not a valid date', async () => {
-		// TS-TODO: Remove cast to any
 		const result = triggers.getNextExecutionDate(
-			{
+			ctx.jellyfish.defaults({
 				type: 'triggered-action@1.0.0',
 				slug: ctx.generateRandomSlug({
 					prefix: 'triggered-action',
@@ -1482,7 +1500,36 @@ describe('.getNextExecutionDate()', () => {
 						},
 					},
 				},
-			} as any,
+			}) as TriggeredActionContract,
+		);
+
+		expect(result!.getTime()).toBe(0);
+	});
+
+	it('should return epoch if last execution date is not a valid date', async () => {
+		// TS-TODO: Remove cast to any
+		const result = triggers.getNextExecutionDate(
+			ctx.jellyfish.defaults({
+				type: 'triggered-action@1.0.0',
+				slug: ctx.generateRandomSlug({
+					prefix: 'triggered-action',
+				}),
+				version: '1.0.0',
+				active: true,
+				links: {},
+				tags: [],
+				markers: [],
+				data: {
+					interval: 'PT1H',
+					action: 'action-create-card@1.0.0',
+					target: typeCard.id,
+					arguments: {
+						properties: {
+							slug: 'foo',
+						},
+					},
+				},
+			}) as TriggeredActionContract,
 			new Date('foobar'),
 		);
 
@@ -1492,7 +1539,7 @@ describe('.getNextExecutionDate()', () => {
 	it('should return epoch if last execution date is not a date', async () => {
 		// TS-TODO: fix cast
 		const result = triggers.getNextExecutionDate(
-			{
+			ctx.jellyfish.defaults({
 				type: 'triggered-action@1.0.0',
 				slug: ctx.generateRandomSlug({
 					prefix: 'triggered-action',
@@ -1512,7 +1559,7 @@ describe('.getNextExecutionDate()', () => {
 						},
 					},
 				},
-			} as any,
+			}) as TriggeredActionContract,
 			'foobar' as any,
 		);
 
@@ -1525,7 +1572,7 @@ describe('.getNextExecutionDate()', () => {
 		expect(() => {
 			// TS-TODO: fix cast
 			triggers.getNextExecutionDate(
-				{
+				ctx.jellyfish.defaults({
 					type: 'triggered-action@1.0.0',
 					slug: ctx.generateRandomSlug({
 						prefix: 'triggered-action',
@@ -1545,7 +1592,7 @@ describe('.getNextExecutionDate()', () => {
 							},
 						},
 					},
-				} as any,
+				}) as TriggeredActionContract,
 				date,
 			);
 		}).toThrow(errors.WorkerInvalidDuration);
@@ -1554,7 +1601,7 @@ describe('.getNextExecutionDate()', () => {
 	it('should return the next interval after the last execution', async () => {
 		// TS-TODO: fix cast
 		const result = triggers.getNextExecutionDate(
-			{
+			ctx.jellyfish.defaults({
 				type: 'triggered-action@1.0.0',
 				slug: ctx.generateRandomSlug({
 					prefix: 'triggered-action',
@@ -1575,7 +1622,7 @@ describe('.getNextExecutionDate()', () => {
 						},
 					},
 				},
-			} as any,
+			}) as TriggeredActionContract,
 			new Date('2018-01-01T05:30:00.000Z'),
 		);
 
@@ -1585,7 +1632,7 @@ describe('.getNextExecutionDate()', () => {
 	it('should return the start date if the last execution happened way before the start date', async () => {
 		// TS-TODO: fix cast to any
 		const result = triggers.getNextExecutionDate(
-			{
+			ctx.jellyfish.defaults({
 				type: 'triggered-action@1.0.0',
 				slug: ctx.generateRandomSlug({
 					prefix: 'triggered-action',
@@ -1606,7 +1653,7 @@ describe('.getNextExecutionDate()', () => {
 						},
 					},
 				},
-			} as any,
+			}) as TriggeredActionContract,
 			new Date('2018-01-01T01:00:00.000Z'),
 		);
 
@@ -1616,7 +1663,7 @@ describe('.getNextExecutionDate()', () => {
 	it('should return the subsequent interval if the last execution happened just before the start date', async () => {
 		// TS-TODO: fix cast to any
 		const result = triggers.getNextExecutionDate(
-			{
+			ctx.jellyfish.defaults({
 				type: 'triggered-action@1.0.0',
 				slug: ctx.generateRandomSlug({
 					prefix: 'triggered-action',
@@ -1637,7 +1684,7 @@ describe('.getNextExecutionDate()', () => {
 						},
 					},
 				},
-			} as any,
+			}) as TriggeredActionContract,
 			new Date('2018-01-01T04:50:00.000Z'),
 		);
 
@@ -1647,7 +1694,7 @@ describe('.getNextExecutionDate()', () => {
 	it('should return the next interval if the last execution is the start date', async () => {
 		// TS-TODO: Fix cast to any
 		const result = triggers.getNextExecutionDate(
-			{
+			ctx.jellyfish.defaults({
 				type: 'triggered-action@1.0.0',
 				slug: ctx.generateRandomSlug({
 					prefix: 'triggered-action',
@@ -1668,7 +1715,7 @@ describe('.getNextExecutionDate()', () => {
 						},
 					},
 				},
-			} as any,
+			}) as TriggeredActionContract,
 			new Date('2018-01-01T05:00:00.000Z'),
 		);
 


### PR DESCRIPTION

Instead of having multiple formats for triggers in the system this
changes the worker to handle triggered-action contracts directly,
dramatically simplifying code.

Change-type: major
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>