### PR TITLE
Only disable internal patch bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,10 +9,7 @@
         "peerDependencies"
       ],
       "packagePatterns": ["@balena/jellyfish-*"],
-      "updateTypes": [
-        "minor",
-        "patch"
-      ],
+      "updateTypes": ["patch"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Updating rules we have to avoid an infinite Renovate bump loop situation. We should at least be able to drop the `minor` from that ignored group as Renovate bumps don't currently create anything more than a `patch`.