### PR TITLE
Include versioned type contracts in action context object

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -290,7 +290,10 @@ export class Worker {
 					patch,
 				);
 			},
-			cards: this.jellyfish.cards,
+			cards: {
+				...this.jellyfish.cards,
+				...self.getTypeContracts(),
+			},
 		};
 	}
 

--- a/test/integration/helpers.ts
+++ b/test/integration/helpers.ts
@@ -13,6 +13,7 @@ import {
 	Context,
 	Contract,
 	SessionContract,
+	TypeContract,
 	UserContract,
 } from '@balena/jellyfish-types/build/core';
 import * as queue from '@balena/jellyfish-queue';
@@ -241,6 +242,20 @@ export const before = async (
 		testQueue.producer,
 	);
 	await testWorker.initialize(context);
+
+	const types = await jellyfish.query<TypeContract>(
+		context,
+		adminSessionToken,
+		{
+			type: 'object',
+			properties: {
+				type: {
+					const: 'type@1.0.0',
+				},
+			},
+		},
+	);
+	testWorker.setTypeContracts(context, types);
 
 	// The flush method gives us a way of manually executing enqueued action requests,
 	// allowing fine grained control in test scenarios. In a production setting, the

--- a/test/integration/index.spec.ts
+++ b/test/integration/index.spec.ts
@@ -2698,4 +2698,34 @@ describe('.patchCard()', () => {
 
 		expect(triggers).toEqual([]);
 	});
+
+	describe('.getActionContext()', () => {
+		it('should include a map of type contracts', async () => {
+			const types = await ctx.jellyfish.query<core.TypeContract>(
+				ctx.context,
+				ctx.session,
+				{
+					type: 'object',
+					properties: {
+						type: {
+							const: 'type@1.0.0',
+						},
+					},
+				},
+			);
+
+			ctx.worker.setTypeContracts(ctx.context, types);
+
+			const actionContext = ctx.worker.getActionContext(ctx.context);
+
+			const hasAllTypes = _.every(types, (contract) => {
+				return _.has(
+					actionContext.cards,
+					`${contract.slug}@${contract.version}`,
+				);
+			});
+
+			expect(hasAllTypes).toBeTruthy();
+		});
+	});
 });


### PR DESCRIPTION
Include the cache of versioned type contracts in the action context
provided to action functions. This change allows us to utilise cache
instead of having action functions load type contracts themselves.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>