### PR TITLE
make triggered actions only run if it's a fresh match or an important field changed

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1265,6 +1265,7 @@ export class Worker {
 				const request = await triggersLib.getRequest(
 					this.jellyfish,
 					trigger,
+					current,
 					insertedCard,
 					{
 						currentDate: new Date(),

--- a/lib/triggers.spec.ts
+++ b/lib/triggers.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import * as triggers from './triggers';
+
+describe('.findUsedPropertyPaths()', () => {
+	test('finds all final paths', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				type: { const: 'task@1.0.0' },
+				data: {
+					type: 'object',
+					properties: {
+						p1: { type: 'string' },
+						p2: {
+							type: 'object',
+							allOf: [
+								{ properties: { alpha: { type: 'number' } } },
+								{ properties: { beta: { type: 'boolean' } } },
+							],
+						},
+					},
+				},
+			},
+			anyOf: [
+				true,
+				{ $$links: { 'is owned by': true } },
+				{ properties: { name: { const: 'test' } } },
+			],
+		};
+
+		const paths = triggers.findUsedPropertyPaths(schema);
+
+		const expectedPaths = [
+			'type',
+			'data.p1',
+			'data.p2.alpha',
+			'data.p2.beta',
+			'name',
+		];
+		expectedPaths.forEach((p) => expect(paths).toContain(p));
+		expect(paths.length).toEqual(expectedPaths.length);
+	});
+	test('ignores links', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				type: { const: 'task@1.0.0' },
+			},
+			$$links: {
+				'is owned by': {
+					type: 'object',
+					properties: {
+						slug: { const: 'card-1' },
+					},
+				},
+			},
+		};
+
+		const paths = triggers.findUsedPropertyPaths(schema);
+
+		const expectedPaths = ['type'];
+		expectedPaths.forEach((p) => expect(paths).toContain(p));
+		expect(paths.length).toEqual(expectedPaths.length);
+	});
+});


### PR DESCRIPTION
Important fields are all fields that are mentioned in the filter's JSON schema at the end of a path. So if you want to run a trigger for any changes to `/data` but only of `/data/abc = 1` you'll need to define the match on `/data` separately e.g. with a `allOf:[...]`.

This will prevent triggers from running unnecessarily while giving developers better control over when it should run.

Edit: the above is the decision after the discussion in the comments below