### PR TITLE
Skip task creation only when artifactReady is missing

### DIFF
--- a/lib/transformers.ts
+++ b/lib/transformers.ts
@@ -50,10 +50,10 @@ export const evaluate = async ({
 		return null;
 	}
 
-	// Only run transformers with cards with a valid artifact (`data.$transformer.artifactReady` is truthy)
+	// Only run transformers with cards with a valid artifact or which do not have artifacts at all
 	// and their input filter matches now, but didn't match before (or artifact wasn't ready)
 	const readyNow = newCard.data?.$transformer?.artifactReady;
-	if (!readyNow) {
+	if (readyNow === false) {
 		return null;
 	}
 	const artifactReadyChanged =


### PR DESCRIPTION
We only skip task creation if artifactReady is explicitly false, which means it is not ready yet. When missing, it means there is no need for it anyway and thus we do create it.

Change-type: patch
Signed-off-by: Stathis Moraitidis <stathis@balena.io>