### PR TITLE
Remove dev-only peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,12 +89,7 @@
     "typescript": "^4.5.4"
   },
   "peerDependencies": {
-    "@balena/jellyfish-action-library": "^15.1.188",
-    "@balena/jellyfish-core": "^8.2.0",
-    "@balena/jellyfish-environment": "^6.0.1",
-    "@balena/jellyfish-plugin-base": "^2.2.1",
-    "@balena/jellyfish-plugin-default": "^21.2.0",
-    "@balena/jellyfish-queue": "^1.0.385"
+    "@balena/jellyfish-core": "^8.2.0"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"


### PR DESCRIPTION
See: https://github.com/product-os/jellyfish-plugin-default/pull/869.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>