### PR TITLE
Switch to kernel contract function names

### DIFF
--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -75,7 +75,7 @@ export const newContext = async (
 ): Promise<TestContext> => {
 	const queueTestContext = await queueTestUtils.newContext(options);
 
-	const adminSessionContract = (await queueTestContext.kernel.getCardById(
+	const adminSessionContract = (await queueTestContext.kernel.getContractById(
 		queueTestContext.logContext,
 		queueTestContext.session,
 		queueTestContext.session,
@@ -273,7 +273,7 @@ export const newContext = async (
 		expect(result.error).toBe(false);
 		assert(result.data);
 		await flushAll(session);
-		const contract = (await queueTestContext.kernel.getCardById(
+		const contract = (await queueTestContext.kernel.getContractById(
 			queueTestContext.logContext,
 			queueTestContext.session,
 			result.data.id,
@@ -290,12 +290,12 @@ export const newContext = async (
 	) => {
 		// Create the user, only if it doesn't exist yet
 		const userContract =
-			(await queueTestContext.kernel.getCardBySlug<UserContract>(
+			(await queueTestContext.kernel.getContractBySlug<UserContract>(
 				queueTestContext.logContext,
 				queueTestContext.session,
 				`user-${username}@latest`,
 			)) ||
-			(await queueTestContext.kernel.insertCard<UserContract>(
+			(await queueTestContext.kernel.insertContract<UserContract>(
 				queueTestContext.logContext,
 				queueTestContext.session,
 				{
@@ -356,7 +356,7 @@ export const newContext = async (
 		assert(inserted);
 		await flushAll(session);
 
-		const link = await queueTestContext.kernel.getCardById<LinkContract>(
+		const link = await queueTestContext.kernel.getContractById<LinkContract>(
 			queueTestContext.logContext,
 			queueTestContext.session,
 			inserted.id,
@@ -394,7 +394,7 @@ export const newContext = async (
 		assert(inserted);
 		await flushAll(session);
 
-		const contract = await queueTestContext.kernel.getCardById(
+		const contract = await queueTestContext.kernel.getContractById(
 			queueTestContext.logContext,
 			queueTestContext.session,
 			inserted.id,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -61,14 +61,14 @@ export const getActionArgumentsSchema = (
  * @public
  *
  * @param {Object} context - execution context
- * @param {Object} jellyfish - jellyfish instance
+ * @param {Object} kernel - kernel instance
  * @param {String} session - session id
  * @param {Object} object - card properties
  * @returns {Boolean} whether the card exists
  *
  * @example
  * const session = '4a962ad9-20b5-4dd8-a707-bf819593cc84'
- * const hasCard = await utils.hasCard({ ... }, jellyfish, session, {
+ * const hasCard = await utils.hasCard({ ... }, kernel, session, {
  *   id: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
  *   active: true,
  *   data: {
@@ -82,17 +82,20 @@ export const getActionArgumentsSchema = (
  */
 export const hasCard = async (
 	context: LogContext,
-	jellyfish: Kernel,
+	kernel: Kernel,
 	session: string,
 	object: Pick<Contract, 'slug' | 'version' | 'id'>,
 ): Promise<boolean> => {
-	if (object.id && (await jellyfish.getCardById(context, session, object.id))) {
+	if (
+		object.id &&
+		(await kernel.getContractById(context, session, object.id))
+	) {
 		return true;
 	}
 
 	if (
 		object.slug &&
-		(await jellyfish.getCardBySlug(
+		(await kernel.getContractBySlug(
 			context,
 			session,
 			`${object.slug}@${object.version}`,
@@ -135,12 +138,12 @@ export const durationToMs = (duration: string): number => {
 
 export const getActorKey = async (
 	context: LogContext,
-	jellyfish: Kernel,
+	kernel: Kernel,
 	session: string,
 	actorId: string,
 ): Promise<SessionContract> => {
 	const keySlug = `session-action-${actorId}`;
-	const key = await jellyfish.getCardBySlug<SessionContract>(
+	const key = await kernel.getContractBySlug<SessionContract>(
 		context,
 		session,
 		`${keySlug}@1.0.0`,
@@ -155,7 +158,7 @@ export const getActorKey = async (
 		actor: actorId,
 	});
 
-	return jellyfish.replaceCard<SessionContract>(context, session, {
+	return kernel.replaceContract<SessionContract>(context, session, {
 		slug: keySlug,
 		active: true,
 		version: '1.0.0',

--- a/test/integration/actions/action-create-card.spec.ts
+++ b/test/integration/actions/action-create-card.spec.ts
@@ -67,14 +67,14 @@ describe('action-create-card', () => {
 	});
 
 	test('should fail to create an event with an action-create-card', async () => {
-		const cardType = await ctx.kernel.getCardBySlug(
+		const cardType = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
 		);
 		assert(cardType);
 
-		const typeType = await ctx.kernel.getCardBySlug(
+		const typeType = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -182,7 +182,7 @@ describe('action-create-card', () => {
 	});
 
 	test('should create a new card along with a reason', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -276,7 +276,7 @@ describe('action-create-card', () => {
 			},
 		};
 
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -308,7 +308,7 @@ describe('action-create-card', () => {
 		);
 		expect(createResult.error).toBe(false);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			(createResult.data as any).id,

--- a/test/integration/actions/action-create-event.spec.ts
+++ b/test/integration/actions/action-create-event.spec.ts
@@ -230,7 +230,7 @@ describe('action-create-event', () => {
 		);
 		expect(eventResult.error).toBe(false);
 
-		const event = await ctx.kernel.getCardById(
+		const event = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			eventResult.data.id,
@@ -287,7 +287,7 @@ describe('action-create-event', () => {
 		);
 		expect(cardResult.error).toBe(false);
 
-		const result = await ctx.kernel.getCardById(
+		const result = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			cardResult.data.id,

--- a/test/integration/execute.spec.ts
+++ b/test/integration/execute.spec.ts
@@ -17,7 +17,7 @@ afterAll(() => {
 
 describe('.execute()', () => {
 	test('should execute an action', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -53,7 +53,7 @@ describe('.execute()', () => {
 		);
 
 		expect(result.error).toBe(false);
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result.data.id,
@@ -63,12 +63,12 @@ describe('.execute()', () => {
 	});
 
 	test('should execute a triggered action given a matching mode', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
 		);
-		const actionCard = await ctx.kernel.getCardBySlug(
+		const actionCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'action-create-card@latest',
@@ -147,7 +147,7 @@ describe('.execute()', () => {
 
 		await ctx.flushAll(ctx.session);
 
-		const card = await ctx.kernel.getCardBySlug(
+		const card = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${command}@latest`,
@@ -178,12 +178,12 @@ describe('.execute()', () => {
 	});
 
 	test('should not execute a triggered action given a non matching mode', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
 		);
-		const actionCard = await ctx.kernel.getCardBySlug(
+		const actionCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'action-create-card@latest',
@@ -260,7 +260,7 @@ describe('.execute()', () => {
 
 		expect(result.error).toBe(false);
 
-		const card = await ctx.kernel.getCardBySlug(
+		const card = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${command}@latest`,
@@ -268,7 +268,7 @@ describe('.execute()', () => {
 
 		expect(card).toBeFalsy();
 
-		const resultCard = await ctx.kernel.getCardBySlug(
+		const resultCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${slug}@latest`,
@@ -280,12 +280,12 @@ describe('.execute()', () => {
 	});
 
 	test('should execute a triggered action with a top level anyOf', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
 		);
-		const actionCard = await ctx.kernel.getCardBySlug(
+		const actionCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'action-create-card@latest',
@@ -380,7 +380,7 @@ describe('.execute()', () => {
 
 		await ctx.flushAll(ctx.session);
 
-		const card = await ctx.kernel.getCardBySlug(
+		const card = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${command}@latest`,
@@ -389,12 +389,12 @@ describe('.execute()', () => {
 	});
 
 	test('should add a create event when creating a card', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
 		);
-		const actionCard = await ctx.kernel.getCardBySlug(
+		const actionCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'action-create-card@latest',
@@ -458,7 +458,7 @@ describe('.execute()', () => {
 
 	test('should be able to AGGREGATE based on the card timeline', async () => {
 		jest.setTimeout(10 * 1000);
-		const typeType = await ctx.kernel.getCardBySlug(
+		const typeType = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -625,7 +625,7 @@ describe('.execute()', () => {
 	});
 
 	test('AGGREGATE should create a property on the target if it does not exist', async () => {
-		const typeType = await ctx.kernel.getCardBySlug(
+		const typeType = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -763,7 +763,7 @@ describe('.execute()', () => {
 	});
 
 	test('AGGREGATE should work with $$ prefixed properties', async () => {
-		const typeType = await ctx.kernel.getCardBySlug(
+		const typeType = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -906,7 +906,7 @@ describe('.execute()', () => {
 	});
 
 	test('should create a message with tags', async () => {
-		const typeType = await ctx.kernel.getCardBySlug(
+		const typeType = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -1005,7 +1005,7 @@ describe('.execute()', () => {
 
 		expect(messageResult.error).toBe(false);
 
-		const element = await ctx.kernel.getCardById(
+		const element = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			messageResult.data.id,
@@ -1017,12 +1017,12 @@ describe('.execute()', () => {
 	});
 
 	test('should add an execution event to the action request', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
 		);
-		const actionCard = await ctx.kernel.getCardBySlug(
+		const actionCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'action-create-card@latest',
@@ -1082,12 +1082,12 @@ describe('.execute()', () => {
 	});
 
 	test('should execute a triggered action', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
 		);
-		const actionCard = await ctx.kernel.getCardBySlug(
+		const actionCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'action-create-card@latest',
@@ -1164,7 +1164,7 @@ describe('.execute()', () => {
 
 		await ctx.flushAll(ctx.session);
 
-		const card = await ctx.kernel.getCardBySlug(
+		const card = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${command}@latest`,
@@ -1174,7 +1174,7 @@ describe('.execute()', () => {
 
 		await ctx.flushAll(ctx.session);
 
-		const resultCard = await ctx.kernel.getCardBySlug(
+		const resultCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${slug}@latest`,
@@ -1186,7 +1186,7 @@ describe('.execute()', () => {
 	});
 
 	test('should create a card', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -1267,7 +1267,7 @@ describe('.execute()', () => {
 	});
 
 	test('should throw if the actor does not exist', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -1308,7 +1308,7 @@ describe('.execute()', () => {
 	});
 
 	test('should throw if input card does not match the action filter', async () => {
-		const actionCard = await ctx.kernel.getCardBySlug(
+		const actionCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'action-create-card@latest',
@@ -1351,7 +1351,7 @@ describe('.execute()', () => {
 	});
 
 	test('should return an error if the arguments do not match the action', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -1398,7 +1398,7 @@ describe('.execute()', () => {
 		// Remove the library function from the worker instance
 		Reflect.deleteProperty(localCtx.worker.library, action.split('@')[0]);
 
-		const typeCard = await localCtx.kernel.getCardBySlug(
+		const typeCard = await localCtx.kernel.getContractBySlug(
 			localCtx.logContext,
 			localCtx.session,
 			'card@latest',

--- a/test/integration/index.spec.ts
+++ b/test/integration/index.spec.ts
@@ -65,7 +65,7 @@ describe('.getId()', () => {
 
 describe('Worker', () => {
 	it('should not re-enqueue requests after duplicated execute events', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -118,7 +118,7 @@ describe('Worker', () => {
 	});
 
 	it('should evaluate a simple computed property on insertion', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -205,7 +205,7 @@ describe('Worker', () => {
 		);
 		expect(insertResult.error).toBe(false);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			insertResult.data.id,
@@ -236,7 +236,7 @@ describe('Worker', () => {
 	});
 
 	it('should evaluate a simple SUM property on a insertAction', async () => {
-		const typeCard: any = await ctx.kernel.getCardBySlug(
+		const typeCard: any = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -326,7 +326,7 @@ describe('Worker', () => {
 		);
 		expect(insertResult.error).toBe(false);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			insertResult.data.id,
@@ -359,7 +359,7 @@ describe('Worker', () => {
 	});
 
 	it('should evaluate a simple computed property on a JSON Patch move', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -473,7 +473,7 @@ describe('Worker', () => {
 		);
 		expect(updateResult.error).toBe(false);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			updateResult.data.id,
@@ -505,7 +505,7 @@ describe('Worker', () => {
 	});
 
 	it('should evaluate a simple computed property on a JSON Patch copy', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -619,7 +619,7 @@ describe('Worker', () => {
 		);
 		expect(updateResult.error).toBe(false);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			updateResult.data.id,
@@ -651,7 +651,7 @@ describe('Worker', () => {
 	});
 
 	it('should evaluate a simple computed property on a JSON Patch replace', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -764,7 +764,7 @@ describe('Worker', () => {
 		);
 		expect(updateResult.error).toBe(false);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			updateResult.data.id,
@@ -795,7 +795,7 @@ describe('Worker', () => {
 	});
 
 	it('should evaluate a simple computed property on a JSON Patch addition', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -906,7 +906,7 @@ describe('Worker', () => {
 		);
 		expect(updateResult.error).toBe(false);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			updateResult.data.id,
@@ -937,7 +937,7 @@ describe('Worker', () => {
 	});
 
 	it('should throw if the result of the formula is incompatible with the given type', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -1018,7 +1018,7 @@ describe('Worker', () => {
 	});
 
 	it('should not re-enqueue requests after execute failure', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -1079,7 +1079,7 @@ describe('Worker', () => {
 	});
 
 	it('should be able to login as a user with a password', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'user@latest',
@@ -1137,7 +1137,7 @@ describe('Worker', () => {
 		);
 		expect(loginResult.error).toBe(false);
 
-		const session = await ctx.kernel.getCardById(
+		const session = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			loginResult.data.id,
@@ -1274,7 +1274,7 @@ describe('Worker', () => {
 	});
 
 	it('should fail if signing up with the wrong password', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'user@latest',
@@ -1323,7 +1323,7 @@ describe('Worker', () => {
 	});
 
 	it('should post an error execute event if logging in as a disallowed user', async () => {
-		const adminCard = await ctx.kernel.getCardBySlug(
+		const adminCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'user-admin@latest',
@@ -1405,12 +1405,12 @@ describe('Worker', () => {
 			}) as TriggeredActionContract,
 		]);
 
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
 		);
-		const actionCard = await ctx.kernel.getCardBySlug(
+		const actionCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'action-create-card@latest',
@@ -1449,7 +1449,7 @@ describe('Worker', () => {
 
 		await Promise.all(
 			[1, 2, 3].map(async (idx) => {
-				const card = await ctx.kernel.getCardBySlug(
+				const card = await ctx.kernel.getContractBySlug(
 					ctx.logContext,
 					ctx.session,
 					`${slug}${idx}@latest`,
@@ -1530,12 +1530,12 @@ describe('Worker', () => {
 			}) as TriggeredActionContract,
 		]);
 
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
 		);
-		const actionCard = await ctx.kernel.getCardBySlug(
+		const actionCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'action-create-card@latest',
@@ -1574,7 +1574,7 @@ describe('Worker', () => {
 
 		await Promise.all(
 			[1, 2, 3].map(async (idx) => {
-				const card = await ctx.kernel.getCardBySlug(
+				const card = await ctx.kernel.getContractBySlug(
 					ctx.logContext,
 					ctx.session,
 					`${slug}${idx}@latest`,
@@ -1694,12 +1694,12 @@ describe('Worker', () => {
 			}) as TriggeredActionContract,
 		]);
 
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
 		);
-		const actionCard = await ctx.kernel.getCardBySlug(
+		const actionCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'action-create-card@latest',
@@ -1764,7 +1764,7 @@ describe('Worker', () => {
 		// Now flush any remaining jobs that have been generated by triggers
 		await ctx.flushAll(ctx.session);
 
-		const result = await ctx.kernel.getCardById(
+		const result = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			card.id,
@@ -1784,7 +1784,7 @@ describe('.getTriggers()', () => {
 
 describe('.replaceCard()', () => {
 	test('should update type contract schema', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -1841,7 +1841,7 @@ describe('.replaceCard()', () => {
 			},
 		);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result1!.id,
@@ -1854,7 +1854,7 @@ describe('.replaceCard()', () => {
 	});
 
 	test('updating a card must have the correct tail', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -1897,7 +1897,7 @@ describe('.replaceCard()', () => {
 			},
 		);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result1!.id,
@@ -1954,7 +1954,7 @@ describe('.replaceCard()', () => {
 	});
 
 	test('should be able to disable event creation', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2008,7 +2008,7 @@ describe('.replaceCard()', () => {
 
 describe('.insertCard()', () => {
 	test('should insert a card', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2035,7 +2035,7 @@ describe('.insertCard()', () => {
 
 		assert(result !== null);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result.id,
@@ -2056,7 +2056,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should ignore an explicit type property', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2089,7 +2089,7 @@ describe('.insertCard()', () => {
 			},
 		);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result!.id,
@@ -2101,7 +2101,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should default active to true', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2121,7 +2121,7 @@ describe('.insertCard()', () => {
 			},
 		);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result!.id,
@@ -2131,7 +2131,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should be able to set active to false', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2152,7 +2152,7 @@ describe('.insertCard()', () => {
 			},
 		);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result!.id,
@@ -2162,7 +2162,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should provide sane defaults for links', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2182,7 +2182,7 @@ describe('.insertCard()', () => {
 			},
 		);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result!.id,
@@ -2192,7 +2192,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should provide sane defaults for tags', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2212,7 +2212,7 @@ describe('.insertCard()', () => {
 			},
 		);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result!.id,
@@ -2222,7 +2222,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should provide sane defaults for data', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2242,7 +2242,7 @@ describe('.insertCard()', () => {
 			},
 		);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result!.id,
@@ -2252,7 +2252,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should be able to set a slug', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2275,7 +2275,7 @@ describe('.insertCard()', () => {
 			},
 		);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result!.id,
@@ -2285,7 +2285,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should be able to set a name', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2306,7 +2306,7 @@ describe('.insertCard()', () => {
 			},
 		);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result!.id,
@@ -2323,7 +2323,7 @@ describe('.insertCard()', () => {
 			version: '1.0.0',
 		});
 
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2348,7 +2348,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should add a create event if attachEvents is true', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2398,7 +2398,7 @@ describe('.insertCard()', () => {
 
 describe('.patchCard()', () => {
 	test('should ignore pointless updates', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2454,7 +2454,7 @@ describe('.patchCard()', () => {
 		expect(result2).toBeFalsy();
 		expect(result3).toBeFalsy();
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			result1.id,
@@ -2470,7 +2470,7 @@ describe('.patchCard()', () => {
 			version: '1.0.0',
 		});
 
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2499,7 +2499,7 @@ describe('.patchCard()', () => {
 			},
 		);
 
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2522,7 +2522,7 @@ describe('.patchCard()', () => {
 			],
 		);
 
-		const card = await ctx.kernel.getCardById(
+		const card = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			previousCard.id,
@@ -2538,7 +2538,7 @@ describe('.patchCard()', () => {
 			version: '1.0.0',
 		});
 
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2600,7 +2600,7 @@ describe('.patchCard()', () => {
 			},
 		});
 
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -2647,7 +2647,7 @@ describe('.patchCard()', () => {
 			},
 		});
 
-		const typeTypeContract = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeTypeContract = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',

--- a/test/integration/insert-card.spec.ts
+++ b/test/integration/insert-card.spec.ts
@@ -43,7 +43,7 @@ afterAll(() => {
 
 describe('.insertCard()', () => {
 	test('should pass a triggered action originator', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -115,7 +115,7 @@ describe('.insertCard()', () => {
 
 		await ctx.flushAll(ctx.session);
 
-		const card = await ctx.kernel.getCardBySlug(
+		const card = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${command}@1.0.0`,
@@ -126,7 +126,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should take an originator option', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -197,7 +197,7 @@ describe('.insertCard()', () => {
 
 		await ctx.flushAll(ctx.session);
 
-		const card = await ctx.kernel.getCardBySlug(
+		const card = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${command}@latest`,
@@ -207,7 +207,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should execute one matching triggered action', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -298,7 +298,7 @@ describe('.insertCard()', () => {
 
 		expect(tail.length).toBe(1);
 
-		const resultCard = await ctx.kernel.getCardBySlug(
+		const resultCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${command}@1.0.0`,
@@ -308,7 +308,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should not execute non-matching triggered actions', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -373,7 +373,7 @@ describe('.insertCard()', () => {
 
 		await ctx.flushAll(ctx.session);
 
-		const resultCard = await ctx.kernel.getCardBySlug(
+		const resultCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${command}@1.0.0`,
@@ -383,7 +383,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should execute more than one matching triggered action', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -484,13 +484,13 @@ describe('.insertCard()', () => {
 
 		await ctx.flushAll(ctx.session);
 
-		const resultCard1 = await ctx.kernel.getCardBySlug(
+		const resultCard1 = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${command1}@1.0.0`,
 		);
 
-		const resultCard2 = await ctx.kernel.getCardBySlug(
+		const resultCard2 = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${command2}@1.0.0`,
@@ -501,7 +501,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should execute the matching triggered actions given more than one', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeCard = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -601,13 +601,13 @@ describe('.insertCard()', () => {
 
 		await ctx.flushAll(ctx.session);
 
-		const resultCard1 = await ctx.kernel.getCardBySlug(
+		const resultCard1 = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${command1}@1.0.0`,
 		);
 
-		const resultCard2 = await ctx.kernel.getCardBySlug(
+		const resultCard2 = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			`${command2}@1.0.0`,
@@ -618,7 +618,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should remove previously inserted type triggered actions if inserting a type', async () => {
-		const typeCard = await ctx.kernel.getCardBySlug(
+		const typeCard = await ctx.kernel.getContractBySlug(
 			ctx.logContext,
 			ctx.session,
 			'card@latest',
@@ -731,7 +731,7 @@ describe('.insertCard()', () => {
 
 		await ctx.flushAll(ctx.session);
 
-		const typeTypeContract = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeTypeContract = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -796,7 +796,7 @@ describe('.insertCard()', () => {
 			},
 		});
 
-		const updatedCard = await ctx.kernel.getCardById(
+		const updatedCard = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			insertedCards[1].id,
@@ -810,7 +810,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should add a triggered action given a type with an AGGREGATE formula', async () => {
-		const typeType = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeType = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -906,7 +906,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should pre-register a triggered action if using AGGREGATE', async () => {
-		const typeType = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeType = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -972,7 +972,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should update pre-registered triggered actions if removing an AGGREGATE', async () => {
-		const typeType = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeType = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -1057,7 +1057,7 @@ describe('.insertCard()', () => {
 	});
 
 	test('should add multiple triggered actions given a type with an AGGREGATE formula', async () => {
-		const typeType = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeType = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
@@ -1202,12 +1202,12 @@ describe('.insertCard()', () => {
 		// * checks if formula in linked to contract was updated
 		// (and lots of sanity checks in the middle)
 
-		const typeType = await ctx.kernel.getCardBySlug<TypeContract>(
+		const typeType = await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'type@latest',
 		);
-		const linkType = (await ctx.kernel.getCardBySlug<TypeContract>(
+		const linkType = (await ctx.kernel.getContractBySlug<TypeContract>(
 			ctx.logContext,
 			ctx.session,
 			'link@latest',

--- a/test/integration/triggers.spec.ts
+++ b/test/integration/triggers.spec.ts
@@ -14,7 +14,7 @@ let typeCard: TypeContract;
 beforeAll(async () => {
 	ctx = await testUtils.newContext();
 
-	const contract = (await ctx.kernel.getCardBySlug(
+	const contract = (await ctx.kernel.getContractBySlug(
 		ctx.logContext,
 		ctx.session,
 		'card@latest',
@@ -1034,7 +1034,7 @@ describe('.getTypeTriggers()', () => {
 			}),
 		);
 
-		const updatedCard = await ctx.kernel.getCardById(
+		const updatedCard = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			insertedCards[0].id,
@@ -1220,7 +1220,7 @@ describe('.getTypeTriggers()', () => {
 			`${typeSlug}@1.0.0`,
 		);
 
-		const updatedCard = await ctx.kernel.getCardById(
+		const updatedCard = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			insertedCards[0].id,
@@ -1335,7 +1335,7 @@ describe('.getTypeTriggers()', () => {
 			`${typeSlug}@1.0.0`,
 		);
 
-		const updatedCard = await ctx.kernel.getCardById(
+		const updatedCard = await ctx.kernel.getContractById(
 			ctx.logContext,
 			ctx.session,
 			insertedCards[0].id,


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Update `kernel` calls:
- `getCardById()` => `getContractById()`
- `getCardBySlug()` => `getContractBySlug()`
- `replaceCard()` => `replaceContract()`

We also need to update `WorkerContext` etc to have its exported function names to match, but that would be a breaking change that we can come back to later.