### PR TITLE
Make getFile optional

### DIFF
--- a/lib/sync/index.ts
+++ b/lib/sync/index.ts
@@ -491,6 +491,17 @@ export class Sync {
 			integration,
 			token,
 			async (integrationInstance) => {
+				if (!integrationInstance.getFile) {
+					context.log.warn(
+						'Not fetching file as the integration does not support this feature',
+						{
+							integration: name,
+						},
+					);
+
+					return null;
+				}
+
 				return integrationInstance.getFile(file);
 			},
 			{

--- a/lib/sync/types.ts
+++ b/lib/sync/types.ts
@@ -56,7 +56,7 @@ export interface Integration {
 		options: { actor: string },
 	) => Promise<SequenceItem[]>;
 
-	getFile: (file: string) => Promise<Buffer>;
+	getFile?: (file: string) => Promise<Buffer>;
 }
 
 export interface IntegrationInitializationOptions {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Make the `getFile()` integration function optional.