### PR TITLE
Use core test utils for create user/session

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -16,7 +16,7 @@ import type {
 	TypeContract,
 } from '@balena/jellyfish-types/build/core';
 import * as errio from 'errio';
-import _ from 'lodash';
+import * as _ from 'lodash';
 import * as fastEquals from 'fast-equals';
 import type { Operation } from 'fast-json-patch';
 import * as skhema from 'skhema';

--- a/lib/plugin/plugin-manager.ts
+++ b/lib/plugin/plugin-manager.ts
@@ -1,8 +1,9 @@
-import _ from 'lodash';
+import { Contract } from '@balena/jellyfish-types/build/core';
+import * as _ from 'lodash';
 import * as semver from 'semver';
 import type { Plugin } from './plugin';
 import type { IntegrationDefinition } from '../sync/types';
-import type { Map } from '../types';
+import type { Action, Map } from '../types';
 
 const validateDependencies = (plugins: Map<Plugin>) => {
 	_.forEach(plugins, (plugin) => {
@@ -67,7 +68,7 @@ export class PluginManager {
 		validateDependencies(this.pluginMap);
 	}
 
-	getCards() {
+	getCards(): Map<Contract> {
 		return mergeMaps(
 			_.mapValues(this.pluginMap, (plugin: Plugin) => plugin.getCards()),
 		);
@@ -81,7 +82,7 @@ export class PluginManager {
 		);
 	}
 
-	getActions() {
+	getActions(): Map<Action> {
 		return mergeMaps(
 			_.mapValues(this.pluginMap, (plugin: Plugin) => plugin.getActions()),
 		);

--- a/lib/plugin/plugin.ts
+++ b/lib/plugin/plugin.ts
@@ -4,7 +4,7 @@ import type {
 	ContractData,
 	ContractDefinition,
 } from '@balena/jellyfish-types/build/core';
-import _ from 'lodash';
+import * as _ from 'lodash';
 import type { IntegrationDefinition } from '../sync';
 import type { Action, Map } from '../types';
 

--- a/lib/sync/index.ts
+++ b/lib/sync/index.ts
@@ -1,9 +1,9 @@
-import strict from 'assert';
 import * as assert from '@balena/jellyfish-assert';
 import type { LogContext } from '@balena/jellyfish-logger';
 import * as metrics from '@balena/jellyfish-metrics';
 import type { Contract } from '@balena/jellyfish-types/build/core';
-import _ from 'lodash';
+import { strict } from 'assert';
+import * as _ from 'lodash';
 import type { Map, WorkerContext } from '../types';
 import * as errors from './errors';
 import * as instance from './instance';

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.8",
-    "@balena/jellyfish-core": "^13.2.0",
+    "@balena/jellyfish-core": "^13.3.0",
     "@balena/jellyfish-jellyscript": "^5.1.9",
     "@balena/jellyfish-logger": "^4.0.19",
     "@balena/jellyfish-queue": "^3.1.8",

--- a/test/integration/actions/action-set-add.spec.ts
+++ b/test/integration/actions/action-set-add.spec.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
-import _ from 'lodash';
+import * as _ from 'lodash';
 import { actionSetAdd } from '../../../lib/actions/action-set-add';
 import { testUtils, WorkerContext } from '../../../lib';
 

--- a/test/integration/execute.spec.ts
+++ b/test/integration/execute.spec.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import { Kernel, testUtils as coreTestUtils } from '@balena/jellyfish-core';
 import type { ActionRequestContract } from '@balena/jellyfish-queue';
-import _ from 'lodash';
+import * as _ from 'lodash';
 import { testUtils, TriggeredActionContract } from '../../lib';
 
 let ctx: testUtils.TestContext;

--- a/test/integration/index.spec.ts
+++ b/test/integration/index.spec.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import { Kernel, testUtils as coreTestUtils } from '@balena/jellyfish-core';
 import type { TypeContract } from '@balena/jellyfish-types/build/core';
-import _ from 'lodash';
+import * as _ from 'lodash';
 import { errors, testUtils, TriggeredActionContract, Worker } from '../../lib';
 import { Sync } from '../../lib/sync';
 

--- a/test/integration/insert-card.spec.ts
+++ b/test/integration/insert-card.spec.ts
@@ -4,7 +4,7 @@ import type {
 	Contract,
 	TypeContract,
 } from '@balena/jellyfish-types/build/core';
-import _ from 'lodash';
+import * as _ from 'lodash';
 import {
 	ActionDefinition,
 	testUtils,

--- a/test/integration/subscriptions.spec.ts
+++ b/test/integration/subscriptions.spec.ts
@@ -1,5 +1,5 @@
 import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
-import _ from 'lodash';
+import * as _ from 'lodash';
 import { testUtils } from '../../lib';
 
 let ctx: testUtils.TestContext;

--- a/test/integration/sync-context.spec.ts
+++ b/test/integration/sync-context.spec.ts
@@ -1,5 +1,5 @@
 import { strict } from 'assert';
-import _ from 'lodash';
+import * as _ from 'lodash';
 import * as uuid from 'uuid';
 import { testUtils } from '../../lib';
 

--- a/test/integration/triggers.spec.ts
+++ b/test/integration/triggers.spec.ts
@@ -4,7 +4,7 @@ import type {
 	Contract,
 	TypeContract,
 } from '@balena/jellyfish-types/build/core';
-import _ from 'lodash';
+import * as _ from 'lodash';
 import {
 	errors,
 	testUtils,


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

- Use `createUser()` and `createSession()` test utils provided `jellyfish-core` 
- Drop own `createUser()` and `createSession()` test util functions
- Fix a number of TS issues