### PR TITLE
Fix the plugin constructor accessing the wrong property in an action definition

### DIFF
--- a/lib/plugin/plugin.ts
+++ b/lib/plugin/plugin.ts
@@ -29,7 +29,10 @@ export abstract class Plugin {
 		this.requires = options.requires || [];
 		this.integrationMap = options.integrationMap || {};
 		const actions = options.actions || [];
-		this.contracts = _.concat(options.contracts || [], _.map(actions, 'card'));
+		this.contracts = _.concat(
+			options.contracts || [],
+			_.map(actions, 'contract'),
+		);
 
 		this.actions = {};
 		for (const action of actions) {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>