### PR TITLE
Add mixins arg to contract builder

### DIFF
--- a/lib/plugin/plugin.ts
+++ b/lib/plugin/plugin.ts
@@ -98,4 +98,4 @@ export interface ActionDefinition<T = ContractData> extends Action {
 
 export type ContractBuilder<T = ContractData> =
 	| ContractDefinition<T>
-	| (() => ContractDefinition<T>);
+	| ((mixins?: any) => ContractDefinition<T>);


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Need to update the function form of `ContractBuilder` to include the possibility of mixins. Without this, it is impossible to update `plugin-default` (and others as well probably) to replace `plugin-base` with `worker`.