### PR TITLE
Simplify the plugin interface

### DIFF
--- a/lib/actions/action-create-card.ts
+++ b/lib/actions/action-create-card.ts
@@ -48,6 +48,7 @@ export const actionCreateCard: ActionDefinition = {
 	handler,
 	contract: {
 		slug: 'action-create-card',
+		version: '1.0.0',
 		type: 'action@1.0.0',
 		name: 'Create a new card',
 		data: {

--- a/lib/actions/action-create-event.ts
+++ b/lib/actions/action-create-event.ts
@@ -121,6 +121,7 @@ export const actionCreateEvent: ActionDefinition = {
 	handler,
 	contract: {
 		slug: 'action-create-event',
+		version: '1.0.0',
 		type: 'action@1.0.0',
 		name: 'Attach an event to a card',
 		data: {

--- a/lib/actions/action-create-session.ts
+++ b/lib/actions/action-create-session.ts
@@ -165,6 +165,7 @@ export const actionCreateSession: ActionDefinition = {
 	handler,
 	contract: {
 		slug: 'action-create-session',
+		version: '1.0.0',
 		type: 'action@1.0.0',
 		name: 'Login as a user',
 		data: {

--- a/lib/actions/action-create-user.ts
+++ b/lib/actions/action-create-user.ts
@@ -74,6 +74,7 @@ export const actionCreateUser: ActionDefinition = {
 	handler,
 	contract: {
 		slug: 'action-create-user',
+		version: '1.0.0',
 		type: 'action@1.0.0',
 		name: 'Create a user',
 		data: {

--- a/lib/actions/action-set-add.ts
+++ b/lib/actions/action-set-add.ts
@@ -74,6 +74,7 @@ export const actionSetAdd: ActionDefinition = {
 	handler,
 	contract: {
 		slug: 'action-set-add',
+		version: '1.0.0',
 		type: 'action@1.0.0',
 		name: 'Add an element to a set',
 		data: {

--- a/lib/actions/action-update-card.ts
+++ b/lib/actions/action-update-card.ts
@@ -56,6 +56,7 @@ export const actionUpdateCard: ActionDefinition = {
 	handler,
 	contract: {
 		slug: 'action-update-card',
+		version: '1.0.0',
 		type: 'action@1.0.0',
 		name: 'Update properties of a card',
 		data: {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,9 +40,8 @@ import * as utils from './utils';
 export { actions, triggersLib, errors, CARDS, utils };
 export { Integration, IntegrationDefinition } from './sync';
 export {
+	ActionContractDefinition,
 	ActionDefinition,
-	ContractBuilder,
-	Plugin,
 	PluginDefinition,
 	PluginIdentity,
 } from './plugin';

--- a/lib/plugin/helpers.ts
+++ b/lib/plugin/helpers.ts
@@ -3,7 +3,7 @@ import type { Contract } from '@balena/jellyfish-types/build/core';
 import _ from 'lodash';
 import type { Integration, IntegrationDefinition } from '../sync';
 import type { Map } from '../types';
-import { ActionDefinition, Plugin, PluginDefinition } from '.';
+import { ActionDefinition, PluginDefinition } from '.';
 
 const commonCard = {
 	tags: [],
@@ -76,26 +76,21 @@ const integrationDefinitionFor = (slug: string): IntegrationDefinition => {
 export const integration1 = integrationDefinitionFor('integration1');
 export const integration2 = integrationDefinitionFor('integration2');
 
-export class TestPlugin extends Plugin {
-	public constructor(definition: Partial<PluginDefinition> = {}) {
-		super(
-			Object.assign(
-				{
-					slug: 'plugin-test',
-					name: 'Test Plugin',
-					version: '1.0.0',
-				},
-				definition,
-			),
-		);
-	}
-}
+export const testPlugin = (definition: Partial<PluginDefinition> = {}) => {
+	return {
+		slug: 'plugin-test',
+		name: 'Test Plugin',
+		version: '1.0.0',
+		...definition,
+	};
+};
 
 export const action1: ActionDefinition = {
 	contract: {
 		slug: 'action-1',
+		version: '1.0.0',
 		type: 'action',
-		data: {},
+		data: { arguments: {} },
 	},
 	handler: async () => null,
 };
@@ -103,8 +98,9 @@ export const action1: ActionDefinition = {
 export const action2: ActionDefinition = {
 	contract: {
 		slug: 'action-2',
+		version: '1.0.0',
 		type: 'action',
-		data: {},
+		data: { arguments: {} },
 	},
 	pre: _.noop,
 	handler: async () => _.pick(card1, 'id', 'slug', 'type', 'version'),

--- a/lib/plugin/index.ts
+++ b/lib/plugin/index.ts
@@ -1,7 +1,6 @@
 export {
+	ActionContractDefinition,
 	ActionDefinition,
-	ContractBuilder,
-	Plugin,
 	PluginDefinition,
 	PluginIdentity,
 } from './plugin';

--- a/lib/plugin/plugin-manager.spec.ts
+++ b/lib/plugin/plugin-manager.spec.ts
@@ -6,7 +6,7 @@ import {
 	card2,
 	integration1,
 	integration2,
-	TestPlugin,
+	testPlugin,
 } from './helpers';
 import { PluginManager } from '.';
 
@@ -14,24 +14,23 @@ describe('PluginManager', () => {
 	describe('validates plugins', () => {
 		test('by throwing an exception if you try and load two plugins with the same slug', () => {
 			const getPluginManager = () =>
-				new PluginManager([() => new TestPlugin(), () => new TestPlugin()]);
+				new PluginManager([testPlugin(), testPlugin()]);
 			expect(getPluginManager).toThrow('Duplicate plugin: plugin-test');
 		});
 
 		test('by throwing an exception if a plugin requires another plugin that is not provided', () => {
 			const getPluginManager = () =>
 				new PluginManager([
-					() =>
-						new TestPlugin({
-							slug: 'plugin-test-2',
-							name: 'Test plugin 2',
-							requires: [
-								{
-									slug: 'plugin-test-1',
-									version: '^2.0.0',
-								},
-							],
-						}),
+					testPlugin({
+						slug: 'plugin-test-2',
+						name: 'Test plugin 2',
+						requires: [
+							{
+								slug: 'plugin-test-1',
+								version: '^2.0.0',
+							},
+						],
+					}),
 				]);
 			expect(getPluginManager).toThrow(
 				"Cannot load plugin 'plugin-test-2' (Test plugin 2) because a plugin it depends on (plugin-test-1) is not loaded",
@@ -41,23 +40,21 @@ describe('PluginManager', () => {
 		test('by throwing an exception if a plugin requires a version of another plugin that is not provided', () => {
 			const getPluginManager = () =>
 				new PluginManager([
-					() =>
-						new TestPlugin({
-							slug: 'plugin-test-1',
-							name: 'Test plugin 1',
-							version: '1.0.0',
-						}),
-					() =>
-						new TestPlugin({
-							slug: 'plugin-test-2',
-							name: 'Test plugin 2',
-							requires: [
-								{
-									slug: 'plugin-test-1',
-									version: '^2.0.0',
-								},
-							],
-						}),
+					testPlugin({
+						slug: 'plugin-test-1',
+						name: 'Test plugin 1',
+						version: '1.0.0',
+					}),
+					testPlugin({
+						slug: 'plugin-test-2',
+						name: 'Test plugin 2',
+						requires: [
+							{
+								slug: 'plugin-test-1',
+								version: '^2.0.0',
+							},
+						],
+					}),
 				]);
 			expect(getPluginManager).toThrow(
 				"Cannot load plugin 'plugin-test-2' (Test plugin 2) " +
@@ -68,23 +65,21 @@ describe('PluginManager', () => {
 		test('but will not throw an exception if a plugin requires a version of another plugin that is provided', () => {
 			const getPluginManager = () =>
 				new PluginManager([
-					() =>
-						new TestPlugin({
-							slug: 'plugin-test-1',
-							name: 'Test plugin 1',
-							version: '1.1.0',
-						}),
-					() =>
-						new TestPlugin({
-							slug: 'plugin-test-2',
-							name: 'Test plugin 2',
-							requires: [
-								{
-									slug: 'plugin-test-1',
-									version: '^1.0.0',
-								},
-							],
-						}),
+					testPlugin({
+						slug: 'plugin-test-1',
+						name: 'Test plugin 1',
+						version: '1.1.0',
+					}),
+					testPlugin({
+						slug: 'plugin-test-2',
+						name: 'Test plugin 2',
+						requires: [
+							{
+								slug: 'plugin-test-1',
+								version: '^1.0.0',
+							},
+						],
+					}),
 				]);
 			expect(getPluginManager).not.toThrow();
 		});
@@ -92,23 +87,21 @@ describe('PluginManager', () => {
 		test('but will not throw an exception if a plugin requires a version of another plugin that is provided as a beta version', () => {
 			const getPluginManager = () =>
 				new PluginManager([
-					() =>
-						new TestPlugin({
-							slug: 'plugin-test-1',
-							name: 'Test plugin 1',
-							version: '1.0.1-beta-1',
-						}),
-					() =>
-						new TestPlugin({
-							slug: 'plugin-test-2',
-							name: 'Test plugin 2',
-							requires: [
-								{
-									slug: 'plugin-test-1',
-									version: '^1.0.0',
-								},
-							],
-						}),
+					testPlugin({
+						slug: 'plugin-test-1',
+						name: 'Test plugin 1',
+						version: '1.0.1-beta-1',
+					}),
+					testPlugin({
+						slug: 'plugin-test-2',
+						name: 'Test plugin 2',
+						requires: [
+							{
+								slug: 'plugin-test-1',
+								version: '^1.0.0',
+							},
+						],
+					}),
 				]);
 			expect(getPluginManager).not.toThrow();
 		});
@@ -117,8 +110,8 @@ describe('PluginManager', () => {
 	describe('.getCards', () => {
 		test('returns an empty object if no cards are supplied to any of the plugins', () => {
 			const pluginManager = new PluginManager([
-				() => new TestPlugin({ slug: 'plugin-test-1' }),
-				() => new TestPlugin({ slug: 'plugin-test-2' }),
+				testPlugin({ slug: 'plugin-test-1' }),
+				testPlugin({ slug: 'plugin-test-2' }),
 			]);
 			const cards = pluginManager.getCards();
 			expect(cards).toEqual({});
@@ -126,18 +119,16 @@ describe('PluginManager', () => {
 
 		test('will throw an exception if different plugins contain duplicate card slugs', () => {
 			const pluginManager = new PluginManager([
-				() =>
-					new TestPlugin({
-						slug: 'plugin-test-1',
-						name: 'Test Plugin 1',
-						contracts: [card1],
-					}),
-				() =>
-					new TestPlugin({
-						slug: 'plugin-test-2',
-						name: 'Test Plugin 2',
-						contracts: [Object.assign({}, card2, { slug: card1.slug })],
-					}),
+				testPlugin({
+					slug: 'plugin-test-1',
+					name: 'Test Plugin 1',
+					contracts: [card1],
+				}),
+				testPlugin({
+					slug: 'plugin-test-2',
+					name: 'Test Plugin 2',
+					contracts: [Object.assign({}, card2, { slug: card1.slug })],
+				}),
 			]);
 			const getCards = () => pluginManager.getCards();
 
@@ -148,15 +139,9 @@ describe('PluginManager', () => {
 
 		test('returns a dictionary of cards, keyed by slug', () => {
 			const pluginManager = new PluginManager([
-				() =>
-					new TestPlugin({
-						contracts: [
-							// Cards can be passed in as objects:
-							card1,
-							// ...or as a function that returns a card
-							() => card2,
-						],
-					}),
+				testPlugin({
+					contracts: [card1, card2],
+				}),
 			]);
 
 			const cards = pluginManager.getCards();
@@ -170,8 +155,8 @@ describe('PluginManager', () => {
 	describe('.getSyncIntegrations', () => {
 		test('returns an empty object if no integrations are supplied to any of the plugins', () => {
 			const pluginManager = new PluginManager([
-				() => new TestPlugin({ slug: 'plugin-test-1' }),
-				() => new TestPlugin({ slug: 'plugin-test-2' }),
+				testPlugin({ slug: 'plugin-test-1' }),
+				testPlugin({ slug: 'plugin-test-2' }),
 			]);
 			const loadedIntegrations = pluginManager.getSyncIntegrations();
 			expect(loadedIntegrations).toEqual({});
@@ -179,17 +164,14 @@ describe('PluginManager', () => {
 
 		test('returns a dictionary of integrations keyed by slug', () => {
 			const pluginManager = new PluginManager([
-				() =>
-					new TestPlugin({
-						slug: 'plugin-test-1',
-						integrationMap: { integration1 },
-					}),
-
-				() =>
-					new TestPlugin({
-						slug: 'plugin-test-2',
-						integrationMap: { integration2 },
-					}),
+				testPlugin({
+					slug: 'plugin-test-1',
+					integrationMap: { integration1 },
+				}),
+				testPlugin({
+					slug: 'plugin-test-2',
+					integrationMap: { integration2 },
+				}),
 			]);
 
 			const loadedIntegrations = pluginManager.getSyncIntegrations();
@@ -204,8 +186,8 @@ describe('PluginManager', () => {
 	describe('.getActions', () => {
 		test('returns an empty object if no actions are supplied to any of the plugins', () => {
 			const pluginManager = new PluginManager([
-				() => new TestPlugin({ slug: 'plugin-test-1' }),
-				() => new TestPlugin({ slug: 'plugin-test-2' }),
+				testPlugin({ slug: 'plugin-test-1' }),
+				testPlugin({ slug: 'plugin-test-2' }),
 			]);
 			const loadedActions = pluginManager.getActions();
 			expect(loadedActions).toEqual({});
@@ -213,24 +195,22 @@ describe('PluginManager', () => {
 
 		test('will throw an exception if duplicate action slugs are found', () => {
 			const pluginManager = new PluginManager([
-				() =>
-					new TestPlugin({
-						slug: 'plugin-test-1',
-						name: 'Test Plugin 1',
-						actions: [action1],
-					}),
-				() =>
-					new TestPlugin({
-						slug: 'plugin-test-2',
-						name: 'Test Plugin 2',
-						actions: [
-							Object.assign({}, action2, {
-								contract: {
-									slug: action1.contract.slug,
-								},
-							}),
-						],
-					}),
+				testPlugin({
+					slug: 'plugin-test-1',
+					name: 'Test Plugin 1',
+					actions: [action1],
+				}),
+				testPlugin({
+					slug: 'plugin-test-2',
+					name: 'Test Plugin 2',
+					actions: [
+						Object.assign({}, action2, {
+							contract: {
+								slug: action1.contract.slug,
+							},
+						}),
+					],
+				}),
 			]);
 
 			const getActions = () => pluginManager.getActions();
@@ -242,17 +222,14 @@ describe('PluginManager', () => {
 
 		test('returns a dictionary of actions keyed by slug', () => {
 			const pluginManager = new PluginManager([
-				() =>
-					new TestPlugin({
-						slug: 'plugin-test-1',
-						actions: [action1],
-					}),
-
-				() =>
-					new TestPlugin({
-						slug: 'plugin-test-2',
-						actions: [action2],
-					}),
+				testPlugin({
+					slug: 'plugin-test-1',
+					actions: [action1],
+				}),
+				testPlugin({
+					slug: 'plugin-test-2',
+					actions: [action2],
+				}),
 			]);
 
 			const loadedActions = pluginManager.getActions();

--- a/lib/plugin/plugin-manager.ts
+++ b/lib/plugin/plugin-manager.ts
@@ -1,38 +1,9 @@
 import { Contract } from '@balena/jellyfish-types/build/core';
 import _ from 'lodash';
 import * as semver from 'semver';
-import type { Plugin } from './plugin';
+import { Plugin, PluginDefinition } from './plugin';
 import type { IntegrationDefinition } from '../sync/types';
 import type { Action, Map } from '../types';
-
-const validateDependencies = (plugins: Map<Plugin>) => {
-	_.forEach(plugins, (plugin) => {
-		_.forEach(plugin.requires, ({ slug, version }) => {
-			const dependency = plugins[slug];
-			if (!semver.validRange(version)) {
-				throw new Error(
-					`Cannot load plugin '${plugin.slug}' (${plugin.name}) ` +
-						`because it specifies an invalid version (${version}) for the dependency on '${slug}'`,
-				);
-			}
-			if (!dependency) {
-				throw new Error(
-					`Cannot load plugin '${plugin.slug}' (${plugin.name}) ` +
-						`because a plugin it depends on (${slug}) is not loaded`,
-				);
-			} else if (
-				!semver.satisfies(dependency.version, version, {
-					includePrerelease: true,
-				})
-			) {
-				throw new Error(
-					`Cannot load plugin '${plugin.slug}' (${plugin.name}) ` +
-						`because a plugin it depends on (${slug}@${version}) is not loaded`,
-				);
-			}
-		});
-	});
-};
 
 const mergeMaps = <T>(maps: Map<Map<T>>): Map<T> => {
 	const merged = {};
@@ -54,27 +25,55 @@ const mergeMaps = <T>(maps: Map<Map<T>>): Map<T> => {
 export class PluginManager {
 	private pluginMap: Map<Plugin>;
 
-	constructor(pluginBuilders: Array<() => Plugin>) {
+	public constructor(pluginDefinitions: PluginDefinition[]) {
 		this.pluginMap = {};
-		for (const pluginBuilder of pluginBuilders) {
-			const plugin = pluginBuilder();
-			if (plugin.slug in this.pluginMap) {
-				throw new Error(`Duplicate plugin: ${plugin.slug}`);
+		for (const pluginDefinition of pluginDefinitions) {
+			if (pluginDefinition.slug in this.pluginMap) {
+				throw new Error(`Duplicate plugin: ${pluginDefinition.slug}`);
 			}
 
-			this.pluginMap[plugin.slug] = plugin;
+			this.pluginMap[pluginDefinition.slug] = new Plugin(pluginDefinition);
 		}
 
-		validateDependencies(this.pluginMap);
+		this.validateDependencies();
 	}
 
-	getCards(): Map<Contract> {
+	private validateDependencies() {
+		_.forEach(this.pluginMap, (plugin) => {
+			_.forEach(plugin.requires, ({ slug, version }) => {
+				const dependency = this.pluginMap[slug];
+				if (!semver.validRange(version)) {
+					throw new Error(
+						`Cannot load plugin '${plugin.slug}' (${plugin.name}) ` +
+							`because it specifies an invalid version (${version}) for the dependency on '${slug}'`,
+					);
+				}
+				if (!dependency) {
+					throw new Error(
+						`Cannot load plugin '${plugin.slug}' (${plugin.name}) ` +
+							`because a plugin it depends on (${slug}) is not loaded`,
+					);
+				} else if (
+					!semver.satisfies(dependency.version, version, {
+						includePrerelease: true,
+					})
+				) {
+					throw new Error(
+						`Cannot load plugin '${plugin.slug}' (${plugin.name}) ` +
+							`because a plugin it depends on (${slug}@${version}) is not loaded`,
+					);
+				}
+			});
+		});
+	}
+
+	public getCards(): Map<Contract> {
 		return mergeMaps(
 			_.mapValues(this.pluginMap, (plugin: Plugin) => plugin.getCards()),
 		);
 	}
 
-	getSyncIntegrations(): Map<IntegrationDefinition> {
+	public getSyncIntegrations(): Map<IntegrationDefinition> {
 		return mergeMaps<IntegrationDefinition>(
 			_.mapValues(this.pluginMap, (plugin: Plugin) =>
 				plugin.getSyncIntegrations(),
@@ -82,7 +81,7 @@ export class PluginManager {
 		);
 	}
 
-	getActions(): Map<Action> {
+	public getActions(): Map<Action> {
 		return mergeMaps(
 			_.mapValues(this.pluginMap, (plugin: Plugin) => plugin.getActions()),
 		);

--- a/lib/plugin/plugin.spec.ts
+++ b/lib/plugin/plugin.spec.ts
@@ -6,23 +6,26 @@ import {
 	card2,
 	integration1,
 	integration2,
-	TestPlugin,
+	testPlugin,
 } from './helpers';
+import { Plugin } from './plugin';
 
 describe('Plugin', () => {
 	describe('validates the plugin', () => {
 		test('by throwing an exception if the plugin does not implement the required interface', () => {
 			const slug = 'Invalid slug';
 			const getPlugin = () =>
-				new TestPlugin({
-					slug: 'Invalid slug',
-				});
+				new Plugin(
+					testPlugin({
+						slug: 'Invalid slug',
+					}),
+				);
 			expect(getPlugin).toThrow(`Invalid slug: ${slug}`);
 		});
 
 		test('by not throwing an exception if the plugin specifies a beta version', () => {
 			const getPlugin = () =>
-				new TestPlugin({
+				testPlugin({
 					version: '1.0.0-some-beta-version',
 				});
 			expect(getPlugin).not.toThrow();
@@ -31,15 +34,17 @@ describe('Plugin', () => {
 
 	describe('.getCards', () => {
 		test('returns an empty object if no cards are supplied to the plugin', () => {
-			const plugin = new TestPlugin({});
+			const plugin = new Plugin(testPlugin());
 			const cards = plugin.getCards();
 			expect(cards).toEqual({});
 		});
 
 		test('throws an exception if duplicate card slugs are found', () => {
-			const plugin = new TestPlugin({
-				contracts: [card1, Object.assign({}, card2, { slug: card1.slug })],
-			});
+			const plugin = new Plugin(
+				testPlugin({
+					contracts: [card1, Object.assign({}, card2, { slug: card1.slug })],
+				}),
+			);
 
 			const getCards = () => plugin.getCards();
 
@@ -47,14 +52,11 @@ describe('Plugin', () => {
 		});
 
 		test('returns a dictionary of cards, keyed by slug', () => {
-			const plugin = new TestPlugin({
-				contracts: [
-					// Cards can be passed in as objects:
-					card1,
-					// ...or as a function that returns a card
-					() => card2,
-				],
-			});
+			const plugin = new Plugin(
+				testPlugin({
+					contracts: [card1, card2],
+				}),
+			);
 
 			const cards = plugin.getCards();
 
@@ -67,18 +69,20 @@ describe('Plugin', () => {
 
 	describe('.getSyncIntegrations', () => {
 		test('returns an empty object if no integrations are supplied to the plugin', () => {
-			const plugin = new TestPlugin({});
+			const plugin = new Plugin(testPlugin());
 			const loadedIntegrations = plugin.getSyncIntegrations();
 			expect(loadedIntegrations).toEqual({});
 		});
 
 		test('returns a dictionary of integrations keyed by slug', () => {
-			const plugin = new TestPlugin({
-				integrationMap: {
-					integration1,
-					integration2,
-				},
-			});
+			const plugin = new Plugin(
+				testPlugin({
+					integrationMap: {
+						integration1,
+						integration2,
+					},
+				}),
+			);
 
 			const loadedIntegrations = plugin.getSyncIntegrations();
 
@@ -91,15 +95,17 @@ describe('Plugin', () => {
 
 	describe('.getActions', () => {
 		test('returns an empty object if no actions are supplied to the plugin', () => {
-			const plugin = new TestPlugin({});
+			const plugin = new Plugin(testPlugin());
 			const loadedActions = plugin.getActions();
 			expect(loadedActions).toEqual({});
 		});
 
 		test('returns a dictionary of actions keyed by slug', () => {
-			const plugin = new TestPlugin({
-				actions: [action1, action2],
-			});
+			const plugin = new Plugin(
+				testPlugin({
+					actions: [action1, action2],
+				}),
+			);
 
 			const loadedActions = plugin.getActions();
 

--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -9,7 +9,7 @@ import type {
 	TypeContract,
 } from '@balena/jellyfish-types/build/core';
 import _ from 'lodash';
-import { ActionDefinition, Plugin, PluginManager } from './plugin';
+import { ActionDefinition, PluginDefinition, PluginManager } from './plugin';
 import { Sync } from './sync';
 import { Action, Map } from './types';
 import { CARDS, Worker } from '.';
@@ -57,7 +57,7 @@ export interface NewContextOptions extends coreTestUtils.NewContextOptions {
 	/**
 	 * Set of plugins needed to run tests.
 	 */
-	plugins?: Array<() => Plugin>;
+	plugins?: PluginDefinition[];
 	actions?: ActionDefinition[];
 }
 

--- a/test/integration/insert-card.spec.ts
+++ b/test/integration/insert-card.spec.ts
@@ -30,6 +30,7 @@ beforeAll(async () => {
 		},
 		contract: {
 			slug: 'action-test-originator',
+			version: '1.0.0',
 			type: actionCreateCard.contract.type,
 			name: actionCreateCard.contract.name,
 			data: actionCreateCard.contract.data,


### PR DESCRIPTION
- Don't export the `Plugin` class. Plugins are now defined as `PluginDefinition` objects.
- Remove the ability to define contracts as functions.
- Remove custom mixins.
- Properly define the type for action contracts.

Change-type: major
Signed-off-by: Carol Schulze <carol@balena.io>