### PR TITLE
Export PluginManager

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -44,6 +44,7 @@ export {
 	ActionDefinition,
 	PluginDefinition,
 	PluginIdentity,
+	PluginManager,
 } from './plugin';
 export * as testUtils from './test-utils';
 export * from './types';


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Export `PluginManager` so consumers can instantiate and work with a plugin manager.