### PR TITLE
Use EventContract for translate() and mirror()

### DIFF
--- a/lib/sync/index.ts
+++ b/lib/sync/index.ts
@@ -1,7 +1,10 @@
 import * as assert from '@balena/jellyfish-assert';
 import type { LogContext } from '@balena/jellyfish-logger';
 import * as metrics from '@balena/jellyfish-metrics';
-import type { Contract } from '@balena/jellyfish-types/build/core';
+import type {
+	Contract,
+	EventContract,
+} from '@balena/jellyfish-types/build/core';
 import { strict } from 'assert';
 import _ from 'lodash';
 import type { Map, WorkerContext } from '../types';
@@ -325,7 +328,7 @@ export class Sync {
 	async mirror(
 		name: string,
 		token: any,
-		card: Contract,
+		card: EventContract,
 		context: syncContext.SyncActionContext,
 		options: {
 			actor: string;
@@ -381,7 +384,7 @@ export class Sync {
 	async translate(
 		name: string,
 		token: string,
-		card: Contract,
+		card: EventContract,
 		context: syncContext.SyncActionContext,
 		options: {
 			actor: string;

--- a/lib/sync/instance.spec.ts
+++ b/lib/sync/instance.spec.ts
@@ -1,4 +1,7 @@
-import type { Contract } from '@balena/jellyfish-types/build/core';
+import type {
+	Contract,
+	EventContract,
+} from '@balena/jellyfish-types/build/core';
 import Bluebird from 'bluebird';
 import _ from 'lodash';
 import nock from 'nock';
@@ -190,7 +193,7 @@ describe('instance', () => {
 				appSecret: '7Fj+Rf1p/fgXTLR505noNwoq7btJaY8KLyIJWE/r',
 			},
 			(object) => {
-				return object.translate({} as Contract, {
+				return object.translate({} as EventContract, {
 					actor: 'b5fc8487-cd6b-46aa-84ec-2407d5989e92',
 				});
 			},
@@ -283,7 +286,7 @@ describe('instance', () => {
 				appSecret: '7Fj+Rf1p/fgXTLR505noNwoq7btJaY8KLyIJWE/r',
 			},
 			(object) => {
-				return object.translate({} as Contract, {
+				return object.translate({} as EventContract, {
 					actor: 'b5fc8487-cd6b-46aa-84ec-2407d5989e92',
 				});
 			},
@@ -398,7 +401,7 @@ describe('instance', () => {
 				appSecret: '7Fj+Rf1p/fgXTLR505noNwoq7btJaY8KLyIJWE/r',
 			},
 			(object) => {
-				return object.translate({} as Contract, {
+				return object.translate({} as EventContract, {
 					actor: 'b5fc8487-cd6b-46aa-84ec-2407d5989e92',
 				});
 			},
@@ -491,7 +494,7 @@ describe('instance', () => {
 				appSecret: '7Fj+Rf1p/fgXTLR505noNwoq7btJaY8KLyIJWE/r',
 			},
 			(object) => {
-				return object.translate({} as Contract, {
+				return object.translate({} as EventContract, {
 					actor: 'b5fc8487-cd6b-46aa-84ec-2407d5989e92',
 				});
 			},
@@ -578,7 +581,7 @@ describe('instance', () => {
 					appSecret: '7Fj+Rf1p/fgXTLR505noNwoq7btJaY8KLyIJWE/r',
 				},
 				(object) => {
-					return object.translate({} as Contract, {
+					return object.translate({} as EventContract, {
 						actor: 'b5fc8487-cd6b-46aa-84ec-2407d5989e92',
 					});
 				},
@@ -627,7 +630,7 @@ describe('instance', () => {
 					appSecret: '7Fj+Rf1p/fgXTLR505noNwoq7btJaY8KLyIJWE/r',
 				},
 				(object) => {
-					return object.translate({} as Contract, {
+					return object.translate({} as EventContract, {
 						actor: 'b5fc8487-cd6b-46aa-84ec-2407d5989e92',
 					});
 				},
@@ -685,7 +688,7 @@ describe('instance', () => {
 					appSecret: '7Fj+Rf1p/fgXTLR505noNwoq7btJaY8KLyIJWE/r',
 				},
 				(object) => {
-					return object.translate({} as Contract, {
+					return object.translate({} as EventContract, {
 						actor: 'b5fc8487-cd6b-46aa-84ec-2407d5989e92',
 					});
 				},

--- a/lib/sync/pipeline.ts
+++ b/lib/sync/pipeline.ts
@@ -1,5 +1,8 @@
 import * as assert from '@balena/jellyfish-assert';
-import type { Contract } from '@balena/jellyfish-types/build/core';
+import type {
+	Contract,
+	EventContract,
+} from '@balena/jellyfish-types/build/core';
 import Bluebird from 'bluebird';
 import jsone from 'json-e';
 import _ from 'lodash';
@@ -16,7 +19,7 @@ const runIntegration = async (
 	integration: IntegrationDefinition,
 	options: PipelineOpts,
 	fn: 'translate' | 'mirror',
-	card: Contract,
+	card: EventContract,
 ): Promise<Contract[]> => {
 	return instance.run(
 		integration,
@@ -259,7 +262,7 @@ export const importCards = async (
  */
 export const translateExternalEvent = async (
 	integration: IntegrationDefinition,
-	externalEvent: Contract,
+	externalEvent: EventContract,
 	options: PipelineOpts,
 ) => {
 	return runIntegration(integration, options, 'translate', externalEvent);
@@ -288,7 +291,7 @@ export const translateExternalEvent = async (
  */
 export const mirrorCard = async (
 	integration: IntegrationDefinition,
-	card: Contract,
+	card: EventContract,
 	options: PipelineOpts,
 ) => {
 	return runIntegration(integration, options, 'mirror', card);

--- a/lib/sync/types.ts
+++ b/lib/sync/types.ts
@@ -1,5 +1,8 @@
 import type { LogContext } from '@balena/jellyfish-logger';
-import type { Contract } from '@balena/jellyfish-types/build/core';
+import type {
+	Contract,
+	EventContract,
+} from '@balena/jellyfish-types/build/core';
 import type { Operation } from 'fast-json-patch';
 import type { Map } from '../types';
 import type { SyncActionContext } from './sync-context';
@@ -47,12 +50,12 @@ export interface Integration {
 	destroy: () => Promise<any>;
 
 	translate: (
-		contract: Contract,
+		contract: EventContract,
 		options: { actor: string },
 	) => Promise<SequenceItem[]>;
 
 	mirror: (
-		contract: Contract,
+		contract: EventContract,
 		options: { actor: string },
 	) => Promise<SequenceItem[]>;
 


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

Trying out requiring `EventContract` instead of `Contract` typed contracts for `translate()` and `mirror()` functions.