### PR TITLE
Speed up translate test runner

### DIFF
--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -678,7 +678,7 @@ export async function webhookScenario(
 			},
 		);
 
-		await context.flushAll(context.session);
+		await context.flush(context.session);
 		const result = await context.queue.producer.waitResults(
 			context.logContext,
 			request,


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Speed up translate tests by executing `flush()` instead of `flushAll()` when processing requests. The original `test-harness` used `flush()` so I must have made a mistake when copying the logic/code over into `worker`. My bad.