### PR TITLE
Optimize flush calls in test utils

### DIFF
--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -283,14 +283,13 @@ export const newContext = async (
 			},
 		});
 
-		await flushAll(session);
+		await flush(session);
 		const result: any = await queueTestContext.queue.producer.waitResults(
 			queueTestContext.logContext,
 			req,
 		);
 		expect(result.error).toBe(false);
 		assert(result.data);
-		await flushAll(session);
 		const contract = (await queueTestContext.kernel.getContractById(
 			queueTestContext.logContext,
 			queueTestContext.session,
@@ -342,7 +341,7 @@ export const newContext = async (
 			},
 		);
 		assert(inserted);
-		await flushAll(session);
+		await flush(session);
 
 		const link = await queueTestContext.kernel.getContractById<LinkContract>(
 			queueTestContext.logContext,


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Remove unnecessary `flushAll()` calls and replace others with `flush()` where possible for optimization.

Note: Need to test beta package with consumer repos before merging as there is a chance some of these `flushAll()` calls are necessary.