### PR TITLE
Simplify test:integration npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "balena-lint --fix lib test",
     "test": "npm run lint && npm run test:unit",
     "test:unit": "jest ./lib",
-    "test:integration": "jest --verbose --maxWorkers=1 --forceExit ./test/integration",
+    "test:integration": "jest test/integration",
     "test:compose": "docker build -t balena/jellyfish-sut:latest . && docker-compose -f docker-compose.test.yml -f docker-compose.yml up --exit-code-from=sut",
     "doc": "typedoc ./lib/ && touch docs/.nojekyll",
     "prepack": "npm run build",


### PR DESCRIPTION
Recent changes make the extra
jest flags unnecessary

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>