### PR TITLE
Oauth: Fix bug where http request failures are not handled correctly

### DIFF
--- a/lib/sync/oauth.spec.ts
+++ b/lib/sync/oauth.spec.ts
@@ -369,4 +369,20 @@ describe('oauth', () => {
 			).rejects.toThrow(oauth.OAuthInvalidOption);
 		});
 	});
+
+	describe('.request()', () => {
+		it('should not throw when given a stauts code > 300', async () => {
+			const code = 401;
+			const body = 'Unauthorized';
+			nock('http://www.example.com').post('/resource').reply(code, body);
+
+			const result = await oauth.request(null, {
+				baseUrl: 'http://www.example.com',
+				uri: '/resource',
+				form: 'foobar',
+			});
+
+			expect(result.code).toEqual(code);
+		});
+	});
 });


### PR DESCRIPTION
If a request to an external resource returns a failure code, the code
should be returned as-is. The axios behaviour is to throw on a status
code > 300, compared to the deprecated request package, which would just
return the status code in its callback params.
The rest of the code actually expects the 300+ error codes and even has
logic to handle them sanely.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>