### PR TITLE
Sync: Improve type safety of SyncContext.request method

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -42,6 +42,8 @@ export {
 	errors as syncErrors,
 	Integration,
 	IntegrationDefinition,
+	IntegrationInitializationOptions,
+	HttpRequestOptions,
 	oauth,
 	SequenceItem,
 } from './sync';

--- a/lib/sync/index.ts
+++ b/lib/sync/index.ts
@@ -10,9 +10,23 @@ import * as instance from './instance';
 import * as oauth from './oauth';
 import * as pipeline from './pipeline';
 import * as syncContext from './sync-context';
-import type { Integration, IntegrationDefinition, SequenceItem } from './types';
+import type {
+	Integration,
+	IntegrationDefinition,
+	IntegrationInitializationOptions,
+	HttpRequestOptions,
+	SequenceItem,
+} from './types';
 
-export { errors, Integration, IntegrationDefinition, oauth, SequenceItem };
+export {
+	errors,
+	Integration,
+	IntegrationDefinition,
+	IntegrationInitializationOptions,
+	HttpRequestOptions,
+	oauth,
+	SequenceItem,
+};
 
 /**
  * Jellyfish sync library module.

--- a/lib/sync/instance.ts
+++ b/lib/sync/instance.ts
@@ -1,6 +1,6 @@
 import * as assert from '@balena/jellyfish-assert';
 import type { Contract } from '@balena/jellyfish-types/build/core';
-import axios, { Method } from 'axios';
+import axios from 'axios';
 import Bluebird from 'bluebird';
 import _ from 'lodash';
 import * as errors from './errors';
@@ -8,26 +8,15 @@ import * as oauth from './oauth';
 import type { SyncActionContext } from './sync-context';
 import type {
 	ActorInformation,
+	HttpRequestOptions,
 	Integration,
 	IntegrationDefinition,
 	PipelineOpts,
 } from './types';
 
 const httpRequest = async <T = any>(
-	options: {
-		method: Method;
-		baseUrl: string;
-		json?: boolean;
-		uri: string;
-		headers?: {
-			[key: string]: string;
-		};
-		data?: {
-			[key: string]: any;
-		};
-		useQuerystring?: boolean;
-	},
-	retries = 30,
+	options: HttpRequestOptions,
+	retries: number = 30,
 ): Promise<{ code: number; body: T }> => {
 	try {
 		const path =
@@ -247,7 +236,7 @@ export const run = async (
 			getElementBySlug: options.context.getElementBySlug,
 			getElementById: options.context.getElementById,
 			getElementByMirrorId: options.context.getElementByMirrorId,
-			request: async (actor: boolean, requestOptions: any) => {
+			request: async (actor: string, requestOptions: HttpRequestOptions) => {
 				assert.INTERNAL(
 					null,
 					actor,

--- a/lib/sync/types.ts
+++ b/lib/sync/types.ts
@@ -1,5 +1,6 @@
 import type { LogContext } from '@balena/jellyfish-logger';
 import type { Contract } from '@balena/jellyfish-types/build/core';
+import type { Method } from 'axios';
 import type { Operation } from 'fast-json-patch';
 import type { Map } from '../types';
 import type { SyncActionContext } from './sync-context';
@@ -59,6 +60,20 @@ export interface Integration {
 	getFile?: (file: string) => Promise<Buffer>;
 }
 
+export interface HttpRequestOptions {
+	method: Method;
+	baseUrl: string;
+	json?: boolean;
+	uri: string;
+	headers?: {
+		[key: string]: string;
+	};
+	data?: {
+		[key: string]: any;
+	};
+	useQuerystring?: boolean;
+}
+
 export interface IntegrationInitializationOptions {
 	token: any;
 	defaultUser: string;
@@ -70,8 +85,8 @@ export interface IntegrationInitializationOptions {
 		getElementById: SyncActionContext['getElementById'];
 		getElementByMirrorId: SyncActionContext['getElementByMirrorId'];
 		request: (
-			actor: boolean,
-			requestOptions: any,
+			actor: string,
+			requestOptions: HttpRequestOptions,
 		) => Promise<{ code: number; body: any }>;
 		getActorId: (information: ActorInformation) => Promise<string>;
 	};


### PR DESCRIPTION
Previously, the `request` method incorrectly typed the `actor` parameter
as a boolean, when it's actually a string, and even worse, cast the
request options argument as `any`.
This change also exports useful types for use by integrations.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>