### PR TITLE
Remove unused js-combinatorics types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@types/bluebird": "^3.5.36",
     "@types/is-uuid": "^1.0.0",
     "@types/jest": "^27.4.0",
-    "@types/js-combinatorics": "^1.2.0",
     "@types/lodash": "^4.14.178",
     "@types/semver": "^7.3.9",
     "@types/sinon": "^10.0.11",


### PR DESCRIPTION
It looks like this package wasn't removed when we switched from
`js-combinatorics` to `just-permutations`.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>