### PR TITLE
Ensure that formulas are evaluated in the correct order 

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.14",
     "@balena/jellyfish-core": "^14.3.6",
-    "@balena/jellyfish-jellyscript": "^5.1.33",
+    "@balena/jellyfish-jellyscript": "^5.1.34",
     "@balena/jellyfish-logger": "^4.0.36",
     "@balena/jellyfish-queue": "^4.0.41",
     "axios": "^0.26.0",


### PR DESCRIPTION
This change fixes a bug where formulas that have output dependent on
another formula field don't update correctly.

Fixes https://github.com/product-os/jellyfish-worker/issues/1360

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>