### PR TITLE
Fix contract export

### DIFF
--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -1,3 +1,4 @@
+import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 import { create } from './create';
 import { scheduledAction } from './scheduled-action';
 import { triggeredAction } from './triggered-action';
@@ -5,12 +6,11 @@ import { update } from './update';
 import { viewAllViews } from './view-all-views';
 import { viewScheduledActions } from './view-scheduled-actions';
 
-// TS-TODO: Load these contracts from a model repo
-export default {
+export const contracts: ContractDefinition[] = [
 	create,
-	'triggered-action': triggeredAction,
-	'scheduled-action': scheduledAction,
+	scheduledAction,
+	triggeredAction,
 	update,
-	'view-all-views': viewAllViews,
-	'view-scheduled-actions': viewScheduledActions,
-};
+	viewAllViews,
+	viewScheduledActions,
+];

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -25,7 +25,7 @@ import * as skhema from 'skhema';
 import { v4 as uuidv4 } from 'uuid';
 import * as formulas from './formulas';
 import { actions } from './actions';
-import CARDS from './contracts';
+import { contracts } from './contracts';
 import * as errors from './errors';
 import * as subscriptionsLib from './subscriptions';
 import { Sync } from './sync';
@@ -41,7 +41,7 @@ import type {
 } from './types';
 import * as utils from './utils';
 
-export { actions, triggersLib, errors, CARDS, utils, Transformer, Sync };
+export { actions, triggersLib, errors, contracts, utils, Transformer, Sync };
 export {
 	errors as syncErrors,
 	Integration,
@@ -310,8 +310,8 @@ export class Worker {
 
 		// Insert worker specific cards
 		await Promise.all(
-			Object.values(CARDS).map(async (card) => {
-				return this.kernel.replaceContract(logContext, this.session, card);
+			Object.values(contracts).map(async (contract) => {
+				return this.kernel.replaceContract(logContext, this.session, contract);
 			}),
 		);
 		await Promise.all(
@@ -698,12 +698,15 @@ export class Worker {
 	 * const worker = new Worker({ ... })
 	 * worker.setTriggers([ ... ])
 	 */
-	setTriggers(logContext: LogContext, contracts: TriggeredActionContract[]) {
+	setTriggers(
+		logContext: LogContext,
+		triggerContracts: TriggeredActionContract[],
+	) {
 		logger.info(logContext, 'Setting triggers', {
 			count: contracts.length,
 		});
 
-		this.triggers = contracts;
+		this.triggers = triggerContracts;
 	}
 
 	/**


### PR DESCRIPTION
We should avoid exporting with default and
instead match other modules by exporting
a typed, named variable.

Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

Marking this as a major change as the exported `CARDS` is replaced with `contracts`. Also, the structure of these exported variables are different even though the content is the same.

Testing with:
- https://github.com/product-os/jellyfish-plugin-github/pull/756
- https://github.com/product-os/jellyfish/pull/8233