### PR TITLE
Pin serialize-error to 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "nock": "^13.2.4",
     "qs": "^6.10.3",
     "semver": "^7.3.5",
-    "serialize-error": "^9.1.0",
+    "serialize-error": "8.1.0",
     "skhema": "^6.0.3",
     "typed-error": "^3.2.1",
     "uuid": "^8.3.2"


### PR DESCRIPTION
As described in
https://github.com/product-os/jellyfish-worker/pull/1348/commits/b129cde1400bbc0eb61ef0a8adabb868828f105e
serialize-error is an esm module as of v9.x which will be a big lift for
us to support across our stack. The original PR didn't pin the version,
which meant that renovate auto-updated it.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>