### PR TITLE
Use latest version of jellyfish-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@balena/jellyfish-assert": "^1.2.15",
     "@balena/jellyfish-core": "^15.0.2",
     "@balena/jellyfish-jellyscript": "^5.1.41",
-    "@balena/jellyfish-logger": "^4.0.40",
+    "@balena/jellyfish-logger": "^5.0.0",
     "@balena/jellyfish-queue": "^4.1.3",
     "axios": "^0.26.0",
     "bcrypt": "^5.0.1",


### PR DESCRIPTION
This major version of the logger no longer handles uncaught exceptions, which would result in mangled and unreadable log messages.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>