### PR TITLE
Bump jellyfish-core, replace createLink helper

### DIFF
--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -1,4 +1,3 @@
-import { strict as assert } from 'assert';
 import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
 import { testUtils as queueTestUtils } from '@balena/jellyfish-queue';
 import type {
@@ -9,14 +8,15 @@ import type {
 	TypeContract,
 } from '@balena/jellyfish-types/build/core';
 import { ExecuteContract } from '@balena/jellyfish-types/build/queue';
-import _ from 'lodash';
+import { strict as assert } from 'assert';
 import permutations from 'just-permutations';
+import _ from 'lodash';
 import nock from 'nock';
 import path from 'path';
+import { CARDS, Worker } from '.';
 import { ActionDefinition, PluginDefinition, PluginManager } from './plugin';
 import { Sync } from './sync';
 import { Action, Map } from './types';
-import { CARDS, Worker } from '.';
 
 /**
  * Context that can be used in tests against the worker.
@@ -42,7 +42,7 @@ export interface TestContext extends queueTestUtils.TestContext {
 		body: string,
 		type: string,
 	) => Promise<any>;
-	createLink: (
+	createLinkThroughWorker: (
 		actor: string,
 		session: string,
 		fromCard: Contract,
@@ -301,7 +301,7 @@ export const newContext = async (
 		return contract;
 	};
 
-	const createLink = async (
+	const createLinkThroughWorker = async (
 		actor: string,
 		session: string,
 		fromCard: Contract,
@@ -400,7 +400,7 @@ export const newContext = async (
 		processAction,
 		retry,
 		createEvent,
-		createLink,
+		createLinkThroughWorker,
 		createContract,
 		worker,
 		...queueTestContext,

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.16",
-    "@balena/jellyfish-core": "^15.0.8",
+    "@balena/jellyfish-core": "^15.1.0",
     "@balena/jellyfish-jellyscript": "^5.1.43",
     "@balena/jellyfish-logger": "^5.0.2",
     "@balena/jellyfish-queue": "^4.1.10",

--- a/test/integration/subscriptions.spec.ts
+++ b/test/integration/subscriptions.spec.ts
@@ -29,7 +29,7 @@ test.skip('Should generate a notification if an event is attached to a contract'
 		'Subscription to foo',
 		{},
 	);
-	await ctx.createLink(
+	await ctx.createLinkThroughWorker(
 		user.id,
 		session.id,
 		root,


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

- Bump `jellyfish-core` to v15.1.0
- Rename `createLink()` test utility to `createLinkThroughWorker()`
  - `jellyfish-core` now supplies a basic `createLink()` test utility, but most times we will want to create links through the worker to ensure dynamically generated link-based triggered actions are triggered and executed