### PR TITLE
Renovate: Ignore serialize-error bumps for now

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "github>product-os/renovate-config"
   ],
+  "ignoreDeps": ["serialize-error"],
   "packageRules": [
     {
       "matchDepTypes": [


### PR DESCRIPTION
Ignoring for now as serialize-error has moved to ESM

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>