### PR TITLE
Use autumndb instead of jellyfish-core

### DIFF
--- a/lib/actions/action-create-event.ts
+++ b/lib/actions/action-create-event.ts
@@ -1,5 +1,5 @@
 import * as assert from '@balena/jellyfish-assert';
-import { errors as coreErrors } from '@balena/jellyfish-core';
+import { errors as coreErrors } from 'autumndb';
 import type { TypeContract } from '@balena/jellyfish-types/build/core';
 import { WorkerNoElement } from '../errors';
 import type { ActionDefinition } from '../plugin';

--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -1,4 +1,4 @@
-import type { Kernel } from '@balena/jellyfish-core';
+import type { Kernel } from 'autumndb';
 import type * as queue from '@balena/jellyfish-queue';
 import * as errors from './errors';
 import { getNextExecutionDate, Worker } from './index';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import * as assert from '@balena/jellyfish-assert';
-import { CARDS as CORE_CARDS, Kernel } from '@balena/jellyfish-core';
+import { CARDS as CORE_CARDS, Kernel } from 'autumndb';
 import { Jellyscript } from '@balena/jellyfish-jellyscript';
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
 import {

--- a/lib/plugin/plugin.ts
+++ b/lib/plugin/plugin.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type {
 	ActionContract,
 	Contract,

--- a/lib/sync/sync-context.ts
+++ b/lib/sync/sync-context.ts
@@ -1,5 +1,5 @@
 import * as assert from '@balena/jellyfish-assert';
-import { Kernel } from '@balena/jellyfish-core';
+import { Kernel } from 'autumndb';
 import { getLogger } from '@balena/jellyfish-logger';
 import type {
 	Contract,

--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { testUtils as queueTestUtils } from '@balena/jellyfish-queue';
 import type {
 	Contract,

--- a/lib/triggers.ts
+++ b/lib/triggers.ts
@@ -1,5 +1,5 @@
 import * as assert from '@balena/jellyfish-assert';
-import type { Kernel } from '@balena/jellyfish-core';
+import type { Kernel } from 'autumndb';
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
 import type { JsonSchema } from '@balena/jellyfish-types';
 import type {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-import type { Kernel } from '@balena/jellyfish-core';
+import type { Kernel } from 'autumndb';
 import type { LogContext } from '@balena/jellyfish-logger';
 import type {
 	ActionContract,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-import type { Kernel } from '@balena/jellyfish-core';
+import type { Kernel } from 'autumndb';
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
 import type { ActionContract } from '@balena/jellyfish-queue';
 import type { JsonSchema } from '@balena/jellyfish-types';

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.18",
     "@balena/jellyfish-client-sdk": "^10.1.10",
-    "@balena/jellyfish-core": "^16.0.10",
     "@balena/jellyfish-jellyscript": "^7.0.0",
     "@balena/jellyfish-logger": "^5.0.6",
     "@balena/jellyfish-queue": "^4.1.20",
+    "autumndb": "^17.0.3",
     "axios": "^0.26.1",
     "bcrypt": "^5.0.1",
     "bluebird": "^3.7.2",

--- a/test/integration/actions/action-create-card.spec.ts
+++ b/test/integration/actions/action-create-card.spec.ts
@@ -1,8 +1,5 @@
 import { strict as assert } from 'assert';
-import {
-	errors as coreErrors,
-	testUtils as coreTestUtils,
-} from '@balena/jellyfish-core';
+import { errors as coreErrors, testUtils as coreTestUtils } from 'autumndb';
 import { testUtils, WorkerContext } from '../../../lib';
 import { actionCreateCard } from '../../../lib/actions/action-create-card';
 import { makeRequest } from './helpers';

--- a/test/integration/actions/action-create-event.spec.ts
+++ b/test/integration/actions/action-create-event.spec.ts
@@ -3,7 +3,7 @@ import {
 	errors as coreErrors,
 	Kernel,
 	testUtils as coreTestUtils,
-} from '@balena/jellyfish-core';
+} from 'autumndb';
 import { testUtils, WorkerContext } from '../../../lib';
 import { actionCreateEvent } from '../../../lib/actions/action-create-event';
 

--- a/test/integration/actions/action-set-add.spec.ts
+++ b/test/integration/actions/action-set-add.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import _ from 'lodash';
 import { actionSetAdd } from '../../../lib/actions/action-set-add';
 import { testUtils, WorkerContext } from '../../../lib';

--- a/test/integration/execute.spec.ts
+++ b/test/integration/execute.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { Kernel, testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { Kernel, testUtils as coreTestUtils } from 'autumndb';
 import type { ActionRequestContract } from '@balena/jellyfish-queue';
 import _ from 'lodash';
 import {

--- a/test/integration/index.spec.ts
+++ b/test/integration/index.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { Kernel, testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { Kernel, testUtils as coreTestUtils } from 'autumndb';
 import type { ProducerOptions } from '@balena/jellyfish-queue';
 import type { TypeContract } from '@balena/jellyfish-types/build/core';
 import _ from 'lodash';

--- a/test/integration/insert-card.spec.ts
+++ b/test/integration/insert-card.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { Kernel, testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { Kernel, testUtils as coreTestUtils } from 'autumndb';
 import type {
 	Contract,
 	TypeContract,

--- a/test/integration/subscriptions.spec.ts
+++ b/test/integration/subscriptions.spec.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import _ from 'lodash';
 import { testUtils } from '../../lib';
 

--- a/test/integration/trigger-updates.spec.ts
+++ b/test/integration/trigger-updates.spec.ts
@@ -1,4 +1,4 @@
-import { Kernel, testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { Kernel, testUtils as coreTestUtils } from 'autumndb';
 import {
 	testUtils,
 	TriggeredActionContract,

--- a/test/integration/triggers.spec.ts
+++ b/test/integration/triggers.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { Kernel, testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { Kernel, testUtils as coreTestUtils } from 'autumndb';
 import type {
 	Contract,
 	TypeContract,

--- a/test/integration/utils.spec.ts
+++ b/test/integration/utils.spec.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { testUtils } from '../../lib';
 import * as utils from '../../lib/utils';
 


### PR DESCRIPTION
The `jellyfish-core` package has been renamed to `autumndb`

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>