### PR TITLE
Export TriggeredActionContractDefinition type

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -37,6 +37,7 @@ import type {
 	ScheduledActionContract,
 	ScheduledActionData,
 	TriggeredActionContract,
+	TriggeredActionContractDefinition,
 	WorkerContext,
 } from './types';
 import * as utils from './utils';


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

We have some code currently using the exported version of this definition from `jellyfish-types` when we should be using it from here.