### PR TITLE
Add option to create links upon contract creation

### DIFF
--- a/lib/actions/action-create-card.ts
+++ b/lib/actions/action-create-card.ts
@@ -1,6 +1,16 @@
 import * as assert from '@balena/jellyfish-assert';
-import type { TypeContract } from '@balena/jellyfish-types/build/core';
+import {
+	getReverseConstraint,
+	linkConstraints,
+} from '@balena/jellyfish-client-sdk';
+import type {
+	Contract,
+	TypeContract,
+} from '@balena/jellyfish-types/build/core';
+import { strict } from 'assert';
+import _ from 'lodash';
 import skhema from 'skhema';
+import { WorkerNoElement } from '../errors';
 import type { ActionDefinition } from '../plugin';
 
 const handler: ActionDefinition['handler'] = async (
@@ -19,6 +29,42 @@ const handler: ActionDefinition['handler'] = async (
 		'You may not use contract actions to create an event',
 	);
 
+	// Prepare link targets if necessary
+	const linkTargets: { [key: string]: Contract[] } = {};
+	if (request.arguments.properties.links) {
+		for (const [verb, links] of Object.entries(
+			request.arguments.properties.links,
+		)) {
+			for (const link of links as any[]) {
+				// Assert the link matches constraints
+				// TODO: Add helper to client-sdk to do this?
+				const predicate = {
+					name: verb,
+					data: {
+						from: typeContract.slug,
+						to: link.type,
+					},
+				};
+				strict(
+					_.find(linkConstraints, predicate),
+					new Error(`Link constraint not found: ${JSON.stringify(predicate)}`),
+				);
+
+				// Assert the contract exists
+				const contract = await context.getCardById(session, link.id);
+				strict(
+					contract,
+					new WorkerNoElement(`Contract for link not found: ${link.id}`),
+				);
+				if (!linkTargets[verb]) {
+					linkTargets[verb] = [];
+				}
+				linkTargets[verb].push(contract);
+			}
+		}
+	}
+
+	// Create new contract
 	const result = await context.insertCard(
 		session,
 		typeContract as TypeContract,
@@ -34,6 +80,50 @@ const handler: ActionDefinition['handler'] = async (
 
 	if (!result) {
 		return null;
+	}
+
+	// Link contract(s) if necessary
+	if (!_.isEmpty(linkTargets)) {
+		const linkTypeContract = await context.getCardBySlug(session, 'link@1.0.0');
+		strict(
+			linkTypeContract,
+			new WorkerNoElement('Link type contract not found'),
+		);
+
+		// TODO: Enqueue by inserting a action request (not yet implemented)
+		for (const [verb, contracts] of Object.entries(linkTargets)) {
+			for (const contract of contracts as any[]) {
+				const reverse = getReverseConstraint(
+					typeContract.slug,
+					contract.type.split('@')[0],
+					verb,
+				);
+				strict(reverse, new Error('Reverse constraint not found'));
+				await context.insertCard(
+					session,
+					linkTypeContract as TypeContract,
+					{},
+					{
+						slug: `link-${result.slug}-${verb.replace(/\s/g, '-')}-${
+							contract.slug
+						}`,
+						type: `${linkTypeContract.slug}@${linkTypeContract.version}`,
+						name: verb,
+						data: {
+							inverseName: reverse.name,
+							from: {
+								id: result.id,
+								type: result.type,
+							},
+							to: {
+								id: contract.id,
+								type: contract.type,
+							},
+						},
+					},
+				);
+			}
+		}
 	}
 
 	return {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.26",
-    "@balena/jellyfish-client-sdk": "^10.3.6",
+    "@balena/jellyfish-client-sdk": "10.4.0-joshbwlng-user-preference-links-a9549d729b16522f8083faf526228c22731608f4",
     "@balena/jellyfish-environment": "^11.0.0",
     "@balena/jellyfish-jellyscript": "^7.0.8",
     "@balena/jellyfish-logger": "^5.0.25",


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Still an experimental work in progress.
Validate and create provided links when creating a new contract with `action-create-card`.

As part of the research associated with this work, I checked on what happens when executing `action-create-card` multiple times on the same versioned slug. AutumnDB throws `JellyfishElementAlreadyExists: There is already an element with slug ...` from [here](https://github.com/product-os/autumndb/blob/master/lib/backend/postgres/cards.ts#L567).