### PR TITLE
Enqueue inserted action requests

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -1,7 +1,6 @@
 import type { Kernel } from 'autumndb';
 import type { Pool } from 'pg';
-import * as errors from './errors';
-import { getNextExecutionDate, Worker } from './index';
+import { Worker } from './index';
 import { TransformerContract } from './types';
 
 function makeTransformer(
@@ -66,102 +65,5 @@ describe('Worker.updateCurrentTransformers()', () => {
 				return tf.id === 'b1.0.0';
 			}),
 		).toBe(true);
-	});
-});
-
-describe('.getNextExecutionDate()', () => {
-	test('should return expected date for one-time schedule', () => {
-		const schedule = {
-			once: {
-				date: new Date(Date.now() + 60000),
-			},
-		};
-		expect(getNextExecutionDate(schedule)).toEqual(schedule.once.date);
-	});
-
-	test('should return expected date for recurring schedule', () => {
-		const now = new Date();
-		const start = new Date(new Date().setMinutes(now.getMinutes() - 10));
-		const end = new Date(new Date().setMinutes(now.getMinutes() + 30));
-
-		const schedule = {
-			recurring: {
-				start,
-				end,
-				interval: '* * * * *',
-			},
-		};
-
-		expect(getNextExecutionDate(schedule)).toEqual(
-			new Date(new Date().setMinutes(now.getMinutes() + 1, 0, 0)),
-		);
-	});
-
-	test('should return null for past one-time schedule', () => {
-		const schedule = {
-			once: {
-				date: new Date(Date.now() - 60000),
-			},
-		};
-
-		expect(getNextExecutionDate(schedule)).toBeNull();
-	});
-
-	test('should return null for recurring schedule with past end date', () => {
-		const now = new Date();
-		const start = new Date(new Date().setMinutes(now.getMinutes() - 30));
-		const end = new Date(new Date().setMinutes(now.getMinutes() - 10));
-
-		const schedule = {
-			recurring: {
-				start,
-				end,
-				interval: '* * * * *',
-			},
-		};
-
-		expect(getNextExecutionDate(schedule)).toBeNull();
-	});
-
-	test('should return expected date for recurring schedule with future start date', () => {
-		const now = new Date();
-		const start = new Date(new Date().setFullYear(now.getFullYear() + 1));
-		const end = new Date(new Date().setFullYear(now.getFullYear() + 2));
-
-		const schedule = {
-			recurring: {
-				start,
-				end,
-				interval: '* * * * *',
-			},
-		};
-
-		expect(getNextExecutionDate(schedule)).toEqual(
-			new Date(new Date(start.getTime() + 60000).setSeconds(0, 0)),
-		);
-	});
-
-	test('should return null for recurring schedule whose start date is after its end date', () => {
-		const schedule = {
-			recurring: {
-				start: new Date(Date.now() - 60000),
-				end: new Date(Date.now() - 120000),
-				interval: '* * * * *',
-			},
-		};
-
-		expect(getNextExecutionDate(schedule)).toBeNull();
-	});
-
-	test('should throw error on invalid schedule configuration', () => {
-		expect(() => {
-			getNextExecutionDate({
-				recurring: {
-					start: new Date(Date.now() - 120000),
-					end: new Date(Date.now() + 120000),
-					interval: 'a b c d e',
-				},
-			});
-		}).toThrowError(errors.WorkerInvalidActionRequest);
 	});
 });

--- a/lib/queue/index.ts
+++ b/lib/queue/index.ts
@@ -13,4 +13,7 @@ export type {
 	ExecuteContract,
 	ExecuteContractDefinition,
 	ExecuteData,
+	ScheduledActionData,
+	ScheduledActionContract,
+	ScheduledActionContractDefinition,
 } from './types';

--- a/lib/queue/producer.spec.ts
+++ b/lib/queue/producer.spec.ts
@@ -1,0 +1,98 @@
+import { getNextExecutionDate } from './producer';
+
+describe('.getNextExecutionDate()', () => {
+	test('should return expected date for one-time schedule', () => {
+		const schedule = {
+			once: {
+				date: new Date(Date.now() + 60000),
+			},
+		};
+		expect(getNextExecutionDate(schedule)).toEqual(schedule.once.date);
+	});
+
+	test('should return expected date for recurring schedule', () => {
+		const now = new Date();
+		const start = new Date(new Date().setMinutes(now.getMinutes() - 10));
+		const end = new Date(new Date().setMinutes(now.getMinutes() + 30));
+
+		const schedule = {
+			recurring: {
+				start,
+				end,
+				interval: '* * * * *',
+			},
+		};
+
+		expect(getNextExecutionDate(schedule)).toEqual(
+			new Date(new Date().setMinutes(now.getMinutes() + 1, 0, 0)),
+		);
+	});
+
+	test('should return null for past one-time schedule', () => {
+		const schedule = {
+			once: {
+				date: new Date(Date.now() - 60000),
+			},
+		};
+
+		expect(getNextExecutionDate(schedule)).toBeNull();
+	});
+
+	test('should return null for recurring schedule with past end date', () => {
+		const now = new Date();
+		const start = new Date(new Date().setMinutes(now.getMinutes() - 30));
+		const end = new Date(new Date().setMinutes(now.getMinutes() - 10));
+
+		const schedule = {
+			recurring: {
+				start,
+				end,
+				interval: '* * * * *',
+			},
+		};
+
+		expect(getNextExecutionDate(schedule)).toBeNull();
+	});
+
+	test('should return expected date for recurring schedule with future start date', () => {
+		const now = new Date();
+		const start = new Date(new Date().setFullYear(now.getFullYear() + 1));
+		const end = new Date(new Date().setFullYear(now.getFullYear() + 2));
+
+		const schedule = {
+			recurring: {
+				start,
+				end,
+				interval: '* * * * *',
+			},
+		};
+
+		expect(getNextExecutionDate(schedule)).toEqual(
+			new Date(new Date(start.getTime() + 60000).setSeconds(0, 0)),
+		);
+	});
+
+	test('should return null for recurring schedule whose start date is after its end date', () => {
+		const schedule = {
+			recurring: {
+				start: new Date(Date.now() - 60000),
+				end: new Date(Date.now() - 120000),
+				interval: '* * * * *',
+			},
+		};
+
+		expect(getNextExecutionDate(schedule)).toBeNull();
+	});
+
+	test('should throw error on invalid schedule configuration', () => {
+		expect(() => {
+			getNextExecutionDate({
+				recurring: {
+					start: new Date(Date.now() - 120000),
+					end: new Date(Date.now() + 120000),
+					interval: 'a b c d e',
+				},
+			});
+		}).toThrowError();
+	});
+});

--- a/lib/queue/types.ts
+++ b/lib/queue/types.ts
@@ -2,6 +2,7 @@ import type {
 	Contract,
 	ContractDefinition,
 } from '@balena/jellyfish-types/build/core';
+import type { ProducerOptions } from './producer';
 
 export interface ActionData {
 	filter?: {
@@ -79,3 +80,24 @@ export interface ExecuteContractDefinition
 	extends ContractDefinition<ExecuteData> {}
 
 export interface ExecuteContract extends Contract<ExecuteData> {}
+
+export interface ScheduledActionData {
+	options: ProducerOptions;
+	schedule: {
+		once?: {
+			date: Date;
+		};
+		recurring?: {
+			start: Date;
+			end: Date;
+			interval: string;
+		};
+	};
+	[k: string]: unknown;
+}
+
+export interface ScheduledActionContractDefinition
+	extends ContractDefinition<ScheduledActionData> {}
+
+export interface ScheduledActionContract
+	extends Contract<ScheduledActionData> {}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -8,11 +8,7 @@ import type {
 } from '@balena/jellyfish-types/build/core';
 import type { Kernel } from 'autumndb';
 import type { Operation } from 'fast-json-patch';
-import type {
-	ActionContract,
-	ActionRequestContract,
-	ProducerOptions,
-} from './queue';
+import type { ActionContract } from './queue';
 
 export interface Action {
 	handler: <TData = ContractData>(
@@ -53,7 +49,7 @@ export interface ActionPreRequest {
 
 export interface WorkerContext {
 	sync: any;
-	getEventSlug: (type: string) => Promise<string>;
+	getEventSlug: (type: string) => string;
 	getCardById: (lsession: string, id: string) => Promise<Contract | null>;
 	getCardBySlug: (lsession: string, slug: string) => Promise<Contract | null>;
 	query: <T extends Contract = Contract>(
@@ -99,10 +95,6 @@ export interface WorkerContext {
 		card: Partial<Contract>,
 		patch: Operation[],
 	) => Promise<Contract | null>;
-	enqueueAction: (
-		session: string,
-		actionRequest: ProducerOptions,
-	) => Promise<ActionRequestContract>;
 	cards: {
 		[slug: string]: ContractDefinition<ContractData>;
 	};
@@ -163,27 +155,6 @@ export interface TriggeredActionContractDefinition
 
 export interface TriggeredActionContract
 	extends Contract<TriggeredActionData> {}
-
-export interface ScheduledActionData {
-	options: ProducerOptions;
-	schedule: {
-		once?: {
-			date: Date;
-		};
-		recurring?: {
-			start: Date;
-			end: Date;
-			interval: string;
-		};
-	};
-	[k: string]: unknown;
-}
-
-export interface ScheduledActionContractDefinition
-	extends ContractDefinition<ScheduledActionData> {}
-
-export interface ScheduledActionContract
-	extends Contract<ScheduledActionData> {}
 
 export interface TransformerData {
 	data: {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -118,9 +118,8 @@ export const hasContract = async (
  * @example
  * const slug = await utils.getEventSlug('execute')
  */
-export const getEventSlug = async (type: string): Promise<string> => {
-	const id = uuidv4();
-	return `${type}-${id}`;
+export const getEventSlug = (type: string): string => {
+	return `${type}-${uuidv4()}`;
 };
 
 /**

--- a/test/integration/actions/action-create-event.spec.ts
+++ b/test/integration/actions/action-create-event.spec.ts
@@ -4,7 +4,7 @@ import {
 	Kernel,
 	testUtils as autumndbTestUtils,
 } from 'autumndb';
-import { testUtils, WorkerContext } from '../../../lib';
+import { ActionRequestContract, testUtils, WorkerContext } from '../../../lib';
 import { actionCreateEvent } from '../../../lib/actions/action-create-event';
 
 let ctx: testUtils.TestContext;
@@ -122,23 +122,34 @@ describe('action-create-event', () => {
 			{ payload: 'test' },
 		);
 
-		const eventRequest = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const eventRequest = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: 'action-create-event@1.0.0',
-				logContext: ctx.logContext,
-				card: root.id,
-				type: root.type,
-				arguments: {
-					type: 'card',
-					tags: [],
-					payload: {
-						message: 'johndoe',
+				data: {
+					action: 'action-create-event@1.0.0',
+					context: ctx.logContext,
+					card: root.id,
+					type: root.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: root.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						type: 'card',
+						tags: [],
+						payload: {
+							message: 'johndoe',
+						},
 					},
 				},
 			},
 		);
+		assert(eventRequest);
 		await ctx.flushAll(ctx.session);
 		const eventResult: any = await ctx.worker.producer.waitResults(
 			ctx.logContext,
@@ -205,24 +216,35 @@ describe('action-create-event', () => {
 			{ payload: 'test' },
 		);
 
-		const eventRequest = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const eventRequest = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: 'action-create-event@1.0.0',
-				logContext: ctx.logContext,
-				card: root.id,
-				type: root.type,
-				arguments: {
-					type: 'card',
-					name: 'Hello world',
-					tags: [],
-					payload: {
-						message: 'johndoe',
+				data: {
+					action: 'action-create-event@1.0.0',
+					context: ctx.logContext,
+					card: root.id,
+					type: root.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: root.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						type: 'card',
+						name: 'Hello world',
+						tags: [],
+						payload: {
+							message: 'johndoe',
+						},
 					},
 				},
 			},
 		);
+		assert(eventRequest);
 		await ctx.flushAll(ctx.session);
 		const eventResult: any = await ctx.worker.producer.waitResults(
 			ctx.logContext,
@@ -263,23 +285,34 @@ describe('action-create-event', () => {
 		);
 		assert(contract);
 
-		const request = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const request = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: 'action-create-event@1.0.0',
-				logContext: ctx.logContext,
-				card: contract.id,
-				type: contract.type,
-				arguments: {
-					type: 'card',
-					tags: [],
-					payload: {
-						message: 'johndoe',
+				data: {
+					action: 'action-create-event@1.0.0',
+					context: ctx.logContext,
+					card: contract.id,
+					type: contract.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: contract.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						type: 'card',
+						tags: [],
+						payload: {
+							message: 'johndoe',
+						},
 					},
 				},
 			},
 		);
+		assert(request);
 		await ctx.flushAll(ctx.session);
 		const contractResult: any = await ctx.worker.producer.waitResults(
 			ctx.logContext,

--- a/test/integration/execute.spec.ts
+++ b/test/integration/execute.spec.ts
@@ -25,31 +25,41 @@ describe('.execute()', () => {
 			ctx.session,
 			'card@latest',
 		);
+		assert(typeContract);
 
-		assert(typeContract !== null);
-
-		const request = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const request = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: 'action-create-card@1.0.0',
-				logContext: ctx.logContext,
-				card: typeContract.id,
-				type: typeContract.type,
-				arguments: {
-					reason: null,
-					properties: {
-						slug: autumndbTestUtils.generateRandomSlug({
-							prefix: 'execute-test',
-						}),
-						version: '1.0.0',
-						data: {
-							foo: 'bar',
+				data: {
+					action: 'action-create-card@1.0.0',
+					context: ctx.logContext,
+					card: typeContract.id,
+					type: typeContract.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: typeContract.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						reason: null,
+						properties: {
+							slug: autumndbTestUtils.generateRandomSlug({
+								prefix: 'execute-test',
+							}),
+							version: '1.0.0',
+							data: {
+								foo: 'bar',
+							},
 						},
 					},
 				},
 			},
 		);
+		assert(request);
 
 		await ctx.flush(ctx.session);
 		const result: any = await ctx.worker.producer.waitResults(
@@ -106,28 +116,39 @@ describe('.execute()', () => {
 			},
 		};
 
-		const request = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const request = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: `${slug}@1.0.0`,
-				logContext: ctx.logContext,
-				card: typeContract.id,
-				type: typeContract.type,
-				arguments: {
-					reason: null,
-					properties: {
-						slug: autumndbTestUtils.generateRandomSlug({
-							prefix: 'execute-test',
-						}),
-						version: '1.0.0',
-						data: {
-							foo: 'bar',
+				data: {
+					action: `${slug}@1.0.0`,
+					context: ctx.logContext,
+					card: typeContract.id,
+					type: typeContract.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: typeContract.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						reason: null,
+						properties: {
+							slug: autumndbTestUtils.generateRandomSlug({
+								prefix: 'execute-test',
+							}),
+							version: '1.0.0',
+							data: {
+								foo: 'bar',
+							},
 						},
 					},
 				},
 			},
 		);
+		assert(request);
 
 		try {
 			await ctx.flush(ctx.session);
@@ -196,26 +217,37 @@ describe('.execute()', () => {
 		);
 
 		const slug = autumndbTestUtils.generateRandomSlug();
-		const request = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const request = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: `${actionContract.slug}@${actionContract.version}`,
-				logContext: ctx.logContext,
-				card: typeContract.id,
-				type: typeContract.type,
-				arguments: {
-					reason: null,
-					properties: {
-						slug,
-						version: '1.0.0',
-						data: {
-							command,
+				data: {
+					action: `${actionContract.slug}@${actionContract.version}`,
+					context: ctx.logContext,
+					card: typeContract.id,
+					type: typeContract.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: typeContract.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						reason: null,
+						properties: {
+							slug,
+							version: '1.0.0',
+							data: {
+								command,
+							},
 						},
 					},
 				},
 			},
 		);
+		assert(request);
 
 		await ctx.flush(ctx.session);
 		const result = await ctx.worker.producer.waitResults(
@@ -311,26 +343,37 @@ describe('.execute()', () => {
 		);
 
 		const slug = autumndbTestUtils.generateRandomSlug();
-		const request = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const request = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: `${actionContract.slug}@${actionContract.version}`,
-				logContext: ctx.logContext,
-				card: typeContract.id,
-				type: typeContract.type,
-				arguments: {
-					reason: null,
-					properties: {
-						slug,
-						version: '1.0.0',
-						data: {
-							command,
+				data: {
+					action: `${actionContract.slug}@${actionContract.version}`,
+					context: ctx.logContext,
+					card: typeContract.id,
+					type: typeContract.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: typeContract.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						reason: null,
+						properties: {
+							slug,
+							version: '1.0.0',
+							data: {
+								command,
+							},
 						},
 					},
 				},
 			},
 		);
+		assert(request);
 
 		await ctx.flush(ctx.session);
 		const result = await ctx.worker.producer.waitResults(
@@ -428,27 +471,37 @@ describe('.execute()', () => {
 			setTimeout(resolve, 5000);
 		});
 
-		const request = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const request = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: `${actionContract.slug}@${actionContract.version}`,
-				logContext: ctx.logContext,
-				card: typeContract.id,
-				type: typeContract.type,
-				arguments: {
-					reason: null,
-					properties: {
-						version: '1.0.0',
-						slug,
-						data: {
-							command,
+				data: {
+					action: `${actionContract.slug}@${actionContract.version}`,
+					context: ctx.logContext,
+					card: typeContract.id,
+					type: typeContract.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: typeContract.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						reason: null,
+						properties: {
+							version: '1.0.0',
+							slug,
+							data: {
+								command,
+							},
 						},
 					},
 				},
 			},
 		);
-
+		assert(request);
 		await ctx.flush(ctx.session);
 
 		const result = await ctx.worker.producer.waitResults(
@@ -484,27 +537,37 @@ describe('.execute()', () => {
 		assert(actionContract !== null);
 
 		const slug = autumndbTestUtils.generateRandomSlug();
-		const request = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const request = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: `${actionContract.slug}@${actionContract.version}`,
-				logContext: ctx.logContext,
-				card: typeContract.id,
-				type: typeContract.type,
-				arguments: {
-					reason: null,
-					properties: {
-						version: '1.0.0',
-						slug,
-						data: {
-							foo: 'bar',
+				data: {
+					action: `${actionContract.slug}@${actionContract.version}`,
+					context: ctx.logContext,
+					card: typeContract.id,
+					type: typeContract.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: typeContract.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						reason: null,
+						properties: {
+							version: '1.0.0',
+							slug,
+							data: {
+								foo: 'bar',
+							},
 						},
 					},
 				},
 			},
 		);
-
+		assert(request);
 		await ctx.flush(ctx.session);
 		const result: any = await ctx.worker.producer.waitResults(
 			ctx.logContext,
@@ -546,37 +609,47 @@ describe('.execute()', () => {
 		assert(typeType !== null);
 
 		const slug = autumndbTestUtils.generateRandomSlug();
-		const request = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const request = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: 'action-create-card@1.0.0',
-				logContext: ctx.logContext,
-				card: typeType.id,
-				type: typeType.type,
-				arguments: {
-					reason: null,
-					properties: {
-						slug,
-						version: '1.0.0',
-						data: {
-							schema: {
-								type: 'object',
-								properties: {
-									type: {
-										type: 'string',
-										const: `${slug}@1.0.0`,
+				data: {
+					action: 'action-create-card@1.0.0',
+					context: ctx.logContext,
+					card: typeType.id,
+					type: typeType.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: typeType.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						reason: null,
+						properties: {
+							slug,
+							version: '1.0.0',
+							data: {
+								schema: {
+									type: 'object',
+									properties: {
+										type: {
+											type: 'string',
+											const: `${slug}@1.0.0`,
+										},
 									},
+									additionalProperties: true,
+									required: ['type'],
 								},
-								additionalProperties: true,
-								required: ['type'],
 							},
 						},
 					},
 				},
 			},
 		);
-
+		assert(request);
 		await ctx.flush(ctx.session);
 		const typeResult: any = await ctx.worker.producer.waitResults(
 			ctx.logContext,
@@ -584,24 +657,34 @@ describe('.execute()', () => {
 		);
 		expect(typeResult.error).toBe(false);
 
-		const threadRequest = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const threadRequest = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: 'action-create-card@1.0.0',
-				logContext: ctx.logContext,
-				card: typeResult.data.id,
-				type: typeResult.data.type,
-				arguments: {
-					reason: null,
-					properties: {
-						slug: autumndbTestUtils.generateRandomSlug(),
-						version: '1.0.0',
+				data: {
+					action: 'action-create-card@1.0.0',
+					context: ctx.logContext,
+					card: typeResult.data.id,
+					type: typeResult.data.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: typeResult.data.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						reason: null,
+						properties: {
+							slug: autumndbTestUtils.generateRandomSlug(),
+							version: '1.0.0',
+						},
 					},
 				},
 			},
 		);
-
+		assert(threadRequest);
 		await ctx.flush(ctx.session);
 		const threadResult: any = await ctx.worker.producer.waitResults(
 			ctx.logContext,
@@ -609,25 +692,35 @@ describe('.execute()', () => {
 		);
 		expect(threadResult.error).toBe(false);
 
-		const messageRequest = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const messageRequest = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: 'action-create-event@1.0.0',
-				logContext: ctx.logContext,
-				card: threadResult.data.id,
-				type: threadResult.data.type,
-				arguments: {
-					type: 'card',
-					tags: ['testtag'],
-					payload: {
-						$$mentions: ['johndoe'],
-						message: 'Hello',
+				data: {
+					action: 'action-create-event@1.0.0',
+					context: ctx.logContext,
+					card: threadResult.data.id,
+					type: threadResult.data.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: threadResult.data.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						type: 'card',
+						tags: ['testtag'],
+						payload: {
+							$$mentions: ['johndoe'],
+							message: 'Hello',
+						},
 					},
 				},
 			},
 		);
-
+		assert(messageRequest);
 		await ctx.flush(ctx.session);
 		const messageResult: any = await ctx.worker.producer.waitResults(
 			ctx.logContext,
@@ -661,27 +754,37 @@ describe('.execute()', () => {
 		assert(typeContract !== null);
 		assert(actionContract !== null);
 
-		const request = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const request = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: `${actionContract.slug}@${actionContract.version}`,
-				logContext: ctx.logContext,
-				card: typeContract.id,
-				type: typeContract.type,
-				arguments: {
-					reason: null,
-					properties: {
-						slug: autumndbTestUtils.generateRandomSlug(),
-						version: '1.0.0',
-						data: {
-							foo: 'bar',
+				data: {
+					action: `${actionContract.slug}@${actionContract.version}`,
+					context: ctx.logContext,
+					card: typeContract.id,
+					type: typeContract.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: typeContract.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						reason: null,
+						properties: {
+							slug: autumndbTestUtils.generateRandomSlug(),
+							version: '1.0.0',
+							data: {
+								foo: 'bar',
+							},
 						},
 					},
 				},
 			},
 		);
-
+		assert(request);
 		await ctx.flush(ctx.session);
 		const result = await ctx.worker.producer.waitResults(
 			ctx.logContext,
@@ -764,27 +867,37 @@ describe('.execute()', () => {
 		);
 
 		const slug = autumndbTestUtils.generateRandomSlug();
-		const request = await ctx.worker.producer.enqueue(
-			ctx.worker.getId(),
+		const request = await ctx.worker.insertCard<ActionRequestContract>(
+			ctx.logContext,
 			ctx.session,
+			ctx.worker.typeContracts['action-request@1.0.0'],
+			{},
 			{
-				action: `${actionContract.slug}@${actionContract.version}`,
-				logContext: ctx.logContext,
-				card: typeContract.id,
-				type: typeContract.type,
-				arguments: {
-					reason: null,
-					properties: {
-						slug,
-						version: '1.0.0',
-						data: {
-							command,
+				data: {
+					action: `${actionContract.slug}@${actionContract.version}`,
+					context: ctx.logContext,
+					card: typeContract.id,
+					type: typeContract.type,
+					actor: ctx.adminUserId,
+					epoch: new Date().valueOf(),
+					input: {
+						id: typeContract.id,
+					},
+					timestamp: new Date().toISOString(),
+					arguments: {
+						reason: null,
+						properties: {
+							slug,
+							version: '1.0.0',
+							data: {
+								command,
+							},
 						},
 					},
 				},
 			},
 		);
-
+		assert(request);
 		await ctx.flush(ctx.session);
 		const result = await ctx.worker.producer.waitResults(
 			ctx.logContext,

--- a/test/integration/queue/events.spec.ts
+++ b/test/integration/queue/events.spec.ts
@@ -7,14 +7,14 @@ import {
 import _ from 'lodash';
 import { events, testUtils } from '../../../lib';
 
-let context: testUtils.TestContext;
+let ctx: testUtils.TestContext;
 
 beforeAll(async () => {
-	context = await testUtils.newContext();
+	ctx = await testUtils.newContext();
 });
 
-afterAll(async () => {
-	await testUtils.destroyContext(context);
+afterAll(() => {
+	return testUtils.destroyContext(ctx);
 });
 
 describe('events', () => {
@@ -22,9 +22,9 @@ describe('events', () => {
 		test('should insert an active execute contract', async () => {
 			const id = autumndbTestUtils.generateRandomId();
 			const event = await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id,
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -40,9 +40,9 @@ describe('events', () => {
 				},
 			);
 
-			const contract = await context.kernel.getContractById(
-				context.logContext,
-				context.session,
+			const contract = await ctx.kernel.getContractById(
+				ctx.logContext,
+				ctx.session,
 				event.id,
 			);
 			expect(contract!.active).toBe(true);
@@ -54,9 +54,9 @@ describe('events', () => {
 			const id = autumndbTestUtils.generateRandomId();
 
 			const contract = await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id,
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -78,9 +78,9 @@ describe('events', () => {
 		test('should not use a passed id', async () => {
 			const id = autumndbTestUtils.generateRandomId();
 			const contract = await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id,
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -103,9 +103,9 @@ describe('events', () => {
 			const id = autumndbTestUtils.generateRandomId();
 			await expect(() => {
 				return events.post(
-					context.logContext,
-					context.kernel,
-					context.session,
+					ctx.logContext,
+					ctx.kernel,
+					ctx.session,
 					{
 						id,
 						action: 'action-create-card@1.0.0',
@@ -125,9 +125,9 @@ describe('events', () => {
 		test('should use the passed timestamp in the payload', async () => {
 			const id = autumndbTestUtils.generateRandomId();
 			const contract = await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id,
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -149,9 +149,9 @@ describe('events', () => {
 
 		test('should allow an object result', async () => {
 			const contract = await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id: autumndbTestUtils.generateRandomId(),
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -177,7 +177,7 @@ describe('events', () => {
 		test('should return when a certain execute event is inserted', (done) => {
 			const id = autumndbTestUtils.generateRandomId();
 			events
-				.wait(context.logContext, context.kernel, context.session, {
+				.wait(ctx.logContext, ctx.kernel, ctx.session, {
 					id,
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 					card: '033d9184-70b2-4ec9-bc39-9a249b186422',
@@ -198,9 +198,9 @@ describe('events', () => {
 			setTimeout(() => {
 				try {
 					return events.post(
-						context.logContext,
-						context.kernel,
-						context.session,
+						ctx.logContext,
+						ctx.kernel,
+						ctx.session,
 						{
 							id,
 							action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -224,9 +224,9 @@ describe('events', () => {
 		test('should return if the contract already exists', async () => {
 			const id = autumndbTestUtils.generateRandomId();
 			await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id,
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -243,9 +243,9 @@ describe('events', () => {
 			);
 
 			const contract = await events.wait(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id,
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -268,7 +268,7 @@ describe('events', () => {
 			const BIG_EXECUTE_CARD = require('./big-execute.json');
 
 			events
-				.wait(context.logContext, context.kernel, context.session, {
+				.wait(ctx.logContext, ctx.kernel, ctx.session, {
 					id: BIG_EXECUTE_CARD.slug.replace(/^execute-/g, ''),
 					action: BIG_EXECUTE_CARD.data.action,
 					card: BIG_EXECUTE_CARD.data.target,
@@ -283,12 +283,8 @@ describe('events', () => {
 
 			setTimeout(() => {
 				try {
-					context.kernel
-						.insertContract(
-							context.logContext,
-							context.session,
-							BIG_EXECUTE_CARD,
-						)
+					ctx.kernel
+						.insertContract(ctx.logContext, ctx.session, BIG_EXECUTE_CARD)
 						.then((execute) => {
 							expect(_.omit(execute, ['id', 'loop'])).toEqual(
 								Object.assign({}, BIG_EXECUTE_CARD, {
@@ -307,9 +303,9 @@ describe('events', () => {
 		test('should be able to access the event payload', async () => {
 			const id = autumndbTestUtils.generateRandomId();
 			await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id,
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -324,9 +320,9 @@ describe('events', () => {
 			);
 
 			const contract = await events.wait(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id,
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -350,7 +346,7 @@ describe('events', () => {
 
 			const id1 = autumndbTestUtils.generateRandomId();
 			events
-				.wait(context.logContext, context.kernel, context.session, {
+				.wait(ctx.logContext, ctx.kernel, ctx.session, {
 					id: id1,
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 					card: '033d9184-70b2-4ec9-bc39-9a249b186422',
@@ -369,9 +365,9 @@ describe('events', () => {
 			setTimeout(async () => {
 				try {
 					await events.post(
-						context.logContext,
-						context.kernel,
-						context.session,
+						ctx.logContext,
+						ctx.kernel,
+						ctx.session,
 						{
 							id: id2,
 							action: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -388,9 +384,9 @@ describe('events', () => {
 					);
 
 					await events.post(
-						context.logContext,
-						context.kernel,
-						context.session,
+						ctx.logContext,
+						ctx.kernel,
+						ctx.session,
 						{
 							id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 							action: '033d9184-70b2-4ec9-bc39-9a249b186422',
@@ -407,9 +403,9 @@ describe('events', () => {
 					);
 
 					await events.post(
-						context.logContext,
-						context.kernel,
-						context.session,
+						ctx.logContext,
+						ctx.kernel,
+						ctx.session,
 						{
 							id: id1,
 							action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -435,9 +431,9 @@ describe('events', () => {
 		test('should return the last execution event given one event', async () => {
 			const id = autumndbTestUtils.generateRandomId();
 			const contract = await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id,
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -453,9 +449,9 @@ describe('events', () => {
 			);
 
 			const event = await events.getLastExecutionEvent(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			);
 
@@ -488,9 +484,9 @@ describe('events', () => {
 			const originator = autumndbTestUtils.generateRandomId();
 
 			const contract1 = await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id: autumndbTestUtils.generateRandomId(),
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -508,9 +504,9 @@ describe('events', () => {
 			);
 
 			await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id: autumndbTestUtils.generateRandomId(),
 					action: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
@@ -528,9 +524,9 @@ describe('events', () => {
 			);
 
 			const event = await events.getLastExecutionEvent(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				originator,
 			);
 
@@ -563,9 +559,9 @@ describe('events', () => {
 			const originator = autumndbTestUtils.generateRandomId();
 
 			const contract1 = await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id: autumndbTestUtils.generateRandomId(),
 					action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -583,9 +579,9 @@ describe('events', () => {
 			);
 
 			await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id: autumndbTestUtils.generateRandomId(),
 					action: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
@@ -603,9 +599,9 @@ describe('events', () => {
 			);
 
 			const event = await events.getLastExecutionEvent(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				originator,
 			);
 
@@ -637,9 +633,9 @@ describe('events', () => {
 
 		test('should return null given no matching event', async () => {
 			await events.post(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				{
 					id: autumndbTestUtils.generateRandomId(),
 					action: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
@@ -657,9 +653,9 @@ describe('events', () => {
 			);
 
 			const event = await events.getLastExecutionEvent(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				autumndbTestUtils.generateRandomId(),
 			);
 			expect(event).toBeNull();
@@ -667,7 +663,7 @@ describe('events', () => {
 
 		test('should only consider execute contracts', async () => {
 			const id = autumndbTestUtils.generateRandomId();
-			await context.kernel.insertContract(context.logContext, context.session, {
+			await ctx.kernel.insertContract(ctx.logContext, ctx.session, {
 				type: 'card@1.0.0',
 				slug: autumndbTestUtils.generateRandomId(),
 				version: '1.0.0',
@@ -686,9 +682,9 @@ describe('events', () => {
 			});
 
 			const event = await events.getLastExecutionEvent(
-				context.logContext,
-				context.kernel,
-				context.session,
+				ctx.logContext,
+				ctx.kernel,
+				ctx.session,
 				id,
 			);
 			expect(event).toBeNull();


### PR DESCRIPTION
Automatically enqueue any inserted action-request
type contracts. Drop support for manually enqueueing
action requests.

Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

Testing with:
- https://github.com/product-os/jellyfish-plugin-product-os/pull/780
- https://github.com/product-os/jellyfish-plugin-default/pull/1109
- https://github.com/product-os/jellyfish-plugin-flowdock/pull/439
- https://github.com/product-os/jellyfish-plugin-github/pull/845
- https://github.com/product-os/jellyfish-plugin-channels/pull/622
- https://github.com/product-os/jellyfish-plugin-typeform/pull/867
- https://github.com/product-os/jellyfish-plugin-outreach/pull/606
- https://github.com/product-os/jellyfish-plugin-balena-api/pull/444
- https://github.com/product-os/jellyfish-plugin-discourse/pull/416
- https://github.com/product-os/jellyfish-plugin-front/pull/461
- https://github.com/product-os/jellyfish/pull/8499