### PR TITLE
Add type and triggered action stream

### DIFF
--- a/test/integration/index.spec.ts
+++ b/test/integration/index.spec.ts
@@ -130,6 +130,88 @@ describe('.getId()', () => {
 });
 
 describe('Worker', () => {
+	it('instance should update on new type contract', async () => {
+		// Insert a new type contract
+		const contract = await ctx.kernel.insertContract<TypeContract>(
+			ctx.logContext,
+			ctx.session,
+			{
+				slug: autumndbTestUtils.generateRandomId(),
+				type: 'type@1.0.0',
+				markers: [],
+				data: {
+					schema: {
+						type: 'object',
+						required: ['name'],
+						properties: {
+							name: {
+								type: 'string',
+							},
+						},
+					},
+				},
+			},
+		);
+		assert(contract);
+
+		// Wait for the stream to update the worker
+		await ctx.retry(
+			() => {
+				return ctx.worker.typeContracts[`${contract.slug}@${contract.version}`];
+			},
+			(typeContract: any) => {
+				return typeContract !== undefined;
+			},
+		);
+	});
+
+	it('instance should update on new triggered-action contract', async () => {
+		// Insert a new triggered action contract
+		const contract = await ctx.kernel.insertContract<TriggeredActionContract>(
+			ctx.logContext,
+			ctx.session,
+			{
+				slug: autumndbTestUtils.generateRandomSlug({
+					prefix: 'triggered-action',
+				}),
+				type: 'triggered-action@1.0.0',
+				markers: [],
+				data: {
+					filter: {
+						type: 'object',
+						required: ['type'],
+						properties: {
+							type: {
+								type: 'string',
+								const: 'foobar@1.0.0',
+							},
+						},
+					},
+					action: 'action-create-card@1.0.0',
+					target: 'card@1.0.0',
+					arguments: {
+						reason: null,
+						properties: {},
+					},
+				},
+			},
+		);
+		assert(contract);
+
+		// Wait for the stream to update the worker
+		await ctx.retry(
+			() => {
+				return _.find(ctx.worker.triggers, { id: contract.id });
+			},
+			(typeContract: any) => {
+				return typeContract !== undefined;
+			},
+		);
+
+		// Remove the test trigger
+		ctx.worker.removeTrigger(ctx.logContext, contract.id);
+	});
+
 	it('should not re-enqueue requests after duplicated execute events', async () => {
 		const typeContract = await ctx.kernel.getContractBySlug(
 			ctx.logContext,


### PR DESCRIPTION
Add stream to keep the worker instance
up to date with type and triggered action
contracts as they are added to the system.

Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

I'd like to deploy this myself as we should remove the type and triggered action portions of the same stream defined in `apps/server`.

Testing in https://github.com/product-os/jellyfish/pull/8410