### PR TITLE
Init worker with plugins

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -2,49 +2,49 @@ import type { Kernel } from 'autumndb';
 import type { Pool } from 'pg';
 import * as errors from './errors';
 import { getNextExecutionDate, Worker } from './index';
-import type { Transformer } from './transformers';
+import { TransformerContract } from './types';
+
+function makeTransformer(
+	id: string,
+	slug: string,
+	version: string,
+): TransformerContract {
+	return {
+		id,
+		slug,
+		type: 'transformer@1.0.0',
+		version,
+		active: true,
+		data: {
+			inputFilter: {},
+			workerFilter: {},
+			requirements: {},
+		},
+		created_at: new Date().toISOString(),
+		tags: [],
+		capabilities: [],
+		requires: [],
+		markers: [],
+	};
+}
 
 describe('Worker.updateCurrentTransformers()', () => {
 	test('should generate properly filtered list of transformers', async () => {
-		const transformers = [
-			{
-				id: 'a1.0.0',
-				slug: 'a-transformer',
-				version: '1.0.0',
-			},
-			{
-				id: 'a1.1.0',
-				slug: 'a-transformer',
-				version: '1.1.0',
-			},
-			{
-				id: 'a1.1.0',
-				slug: 'a-transformer',
-				version: '1.1.1-someprerelease',
-			},
-			{
-				id: 'a2.0.0',
-				slug: 'a-transformer',
-				version: '2.0.0',
-			},
-			{
-				id: 'b1.0.0',
-				slug: 'b-transformer',
-				version: '1.0.0',
-			},
-			{
-				id: 'b0.0.1',
-				slug: 'b-transformer',
-				version: '0.0.1',
-			},
-		] as Transformer[];
+		const transformers: TransformerContract[] = [
+			makeTransformer('a1.0.0', 'a-transformer', '1.0.0'),
+			makeTransformer('a1.1.0', 'a-transformer', '1.1.0'),
+			makeTransformer('a1.1.0', 'a-transformer', '1.1.1-someprerelease'),
+			makeTransformer('a2.0.0', 'a-transformer', '2.0.0'),
+			makeTransformer('b1.0.0', 'b-transformer', '1.0.0'),
+			makeTransformer('b0.0.1', 'b-transformer', '0.0.1'),
+		];
 
 		// TS-TODO: is there a better way to instantiate a simple Worker?
 		const worker = new Worker(
 			{} as any as Kernel,
 			'session-foo',
-			{},
 			{} as any as Pool,
+			[],
 		);
 		worker.transformers = transformers;
 		worker.updateLatestTransformers();

--- a/lib/transformers.spec.ts
+++ b/lib/transformers.spec.ts
@@ -3,9 +3,10 @@ import _ from 'lodash';
 import * as sinon from 'sinon';
 import { v4 as uuid } from 'uuid';
 import * as transformers from './transformers';
+import type { TransformerContract } from './types';
 
 const getEvaluateParamsStub = (
-	transformerContracts: Array<Contract<transformers.TransformerData>>,
+	transformerContracts: TransformerContract[],
 	oldContract: Contract | null,
 	newContract: Contract,
 	returnActor: boolean = true,
@@ -57,15 +58,24 @@ const getEvaluateParamsStub = (
 
 describe('.evaluate()', () => {
 	test('should create a task if a transformer matches a contract that changed artifactReady:false->true', async () => {
-		const transformer = {
+		const transformer: TransformerContract = {
 			id: uuid(),
+			active: true,
+			version: '1.0.0',
 			slug: 'test-transformer',
 			type: 'transformer@1.0.0',
 			data: {
 				inputFilter: {
 					type: 'object',
 				},
+				workerFilter: {},
+				requirements: {},
 			},
+			created_at: new Date().toISOString(),
+			tags: [],
+			markers: [],
+			capabilities: [],
+			requires: [],
 		};
 
 		const oldContract = {
@@ -86,7 +96,7 @@ describe('.evaluate()', () => {
 		};
 
 		const { executeSpy, params } = getEvaluateParamsStub(
-			[transformer as any as Contract<transformers.TransformerData>],
+			[transformer],
 			oldContract as any as Contract,
 			newContract as any as Contract,
 		);
@@ -112,15 +122,24 @@ describe('.evaluate()', () => {
 	});
 
 	test('should create a task if a transformer matches a contract that changed artifactReady:truthy->other-truthy', async () => {
-		const transformer = {
+		const transformer: TransformerContract = {
 			id: uuid(),
+			active: true,
+			version: '1.0.0',
 			slug: 'test-transformer',
 			type: 'transformer@1.0.0',
 			data: {
 				inputFilter: {
 					type: 'object',
 				},
+				workerFilter: {},
+				requirements: {},
 			},
+			created_at: new Date().toISOString(),
+			tags: [],
+			markers: [],
+			capabilities: [],
+			requires: [],
 		};
 
 		const oldContract = {
@@ -141,7 +160,7 @@ describe('.evaluate()', () => {
 		};
 
 		const { executeSpy, params } = getEvaluateParamsStub(
-			[transformer as any as Contract<transformers.TransformerData>],
+			[transformer],
 			oldContract as any as Contract,
 			newContract as any as Contract,
 		);
@@ -167,8 +186,10 @@ describe('.evaluate()', () => {
 	});
 
 	test('should create a task if a transformer matches a contract that was ready before, but only matches now', async () => {
-		const transformer = {
+		const transformer: TransformerContract = {
 			id: uuid(),
+			active: true,
+			version: '1.0.0',
 			slug: 'test-late-match-transformer',
 			type: 'transformer@1.0.0',
 			data: {
@@ -186,7 +207,14 @@ describe('.evaluate()', () => {
 						},
 					},
 				},
+				workerFilter: {},
+				requirements: {},
 			},
+			created_at: new Date().toISOString(),
+			tags: [],
+			markers: [],
+			capabilities: [],
+			requires: [],
 		};
 
 		const oldContract = {
@@ -208,7 +236,7 @@ describe('.evaluate()', () => {
 		};
 
 		const { executeSpy, params } = getEvaluateParamsStub(
-			[transformer as any as Contract<transformers.TransformerData>],
+			[transformer],
 			oldContract as any as Contract,
 			newContract as any as Contract,
 		);
@@ -234,8 +262,10 @@ describe('.evaluate()', () => {
 	});
 
 	test('should only create a task when a transformer matches the input for an updated contract', async () => {
-		const transformer = {
+		const transformer: TransformerContract = {
 			id: uuid(),
+			active: true,
+			version: '1.0.0',
 			slug: 'test-transformer',
 			type: 'transformer@1.0.0',
 			data: {
@@ -248,7 +278,14 @@ describe('.evaluate()', () => {
 						},
 					},
 				},
+				workerFilter: {},
+				requirements: {},
 			},
+			created_at: new Date().toISOString(),
+			tags: [],
+			markers: [],
+			capabilities: [],
+			requires: [],
 		};
 		const oldContract = {
 			type: 'card@1.0.0',
@@ -270,7 +307,7 @@ describe('.evaluate()', () => {
 		};
 
 		const { executeSpy, params } = getEvaluateParamsStub(
-			[transformer as any as Contract<transformers.TransformerData>],
+			[transformer],
 			oldContract as any as Contract,
 			newContract as any as Contract,
 		);
@@ -282,15 +319,24 @@ describe('.evaluate()', () => {
 	});
 
 	test('should create a task even when a there is no previous contract', async () => {
-		const transformer = {
+		const transformer: TransformerContract = {
 			id: uuid(),
+			active: true,
+			version: '1.0.0',
 			slug: 'test-transformer',
 			type: 'transformer@1.0.0',
 			data: {
 				inputFilter: {
 					type: 'object',
 				},
+				workerFilter: {},
+				requirements: {},
 			},
+			created_at: new Date().toISOString(),
+			tags: [],
+			markers: [],
+			capabilities: [],
+			requires: [],
 		};
 
 		const newContract = {
@@ -303,7 +349,7 @@ describe('.evaluate()', () => {
 		};
 
 		const { executeSpy, params } = getEvaluateParamsStub(
-			[transformer as any as Contract<transformers.TransformerData>],
+			[transformer],
 			null,
 			newContract as any as Contract,
 		);
@@ -329,15 +375,24 @@ describe('.evaluate()', () => {
 	});
 
 	test('should not create a task when contract change is not relevant', async () => {
-		const transformer = {
+		const transformer: TransformerContract = {
 			id: uuid(),
+			active: true,
+			version: '1.0.0',
 			slug: 'test-transformer',
 			type: 'transformer@1.0.0',
 			data: {
 				inputFilter: {
 					type: 'object',
 				},
+				workerFilter: {},
+				requirements: {},
 			},
+			created_at: new Date().toISOString(),
+			tags: [],
+			markers: [],
+			capabilities: [],
+			requires: [],
 		};
 
 		const oldContract = {
@@ -362,7 +417,7 @@ describe('.evaluate()', () => {
 		};
 
 		const { executeSpy, params } = getEvaluateParamsStub(
-			[transformer as any as Contract<transformers.TransformerData>],
+			[transformer],
 			oldContract as any as Contract,
 			newContract as any as Contract,
 		);
@@ -374,15 +429,24 @@ describe('.evaluate()', () => {
 	});
 
 	test("should not create a task if a transformer doesn't have an owner", async () => {
-		const transformer = {
+		const transformer: TransformerContract = {
 			id: uuid(),
+			active: true,
+			version: '1.0.0',
 			slug: 'test-transformer',
 			type: 'transformer@1.0.0',
 			data: {
 				inputFilter: {
 					type: 'object',
 				},
+				workerFilter: {},
+				requirements: {},
 			},
+			created_at: new Date().toISOString(),
+			tags: [],
+			markers: [],
+			capabilities: [],
+			requires: [],
 		};
 
 		const oldContract = {
@@ -403,7 +467,7 @@ describe('.evaluate()', () => {
 		};
 
 		const { executeSpy, params } = getEvaluateParamsStub(
-			[transformer as any as Contract<transformers.TransformerData>],
+			[transformer],
 			oldContract as any as Contract,
 			newContract as any as Contract,
 			false,

--- a/lib/transformers.ts
+++ b/lib/transformers.ts
@@ -6,12 +6,12 @@ import _ from 'lodash';
 import * as skhema from 'skhema';
 import { v4 as uuidv4 } from 'uuid';
 import type { ProducerResults } from './queue';
-import type { EnqueueOptions } from './types';
+import type { EnqueueOptions, TransformerContract } from './types';
 
 const logger = getLogger('worker');
 
 export interface EvaluateOptions {
-	transformers: Transformer[];
+	transformers: TransformerContract[];
 	oldContract: Contract<any> | null;
 	newContract: Contract<any>;
 	logContext: LogContext;
@@ -24,13 +24,6 @@ export interface EvaluateOptions {
 		actionRequest: EnqueueOptions,
 	) => Promise<ProducerResults>;
 }
-
-export interface TransformerData {
-	inputFilter: any;
-	workerFilter: any;
-	[key: string]: unknown;
-}
-export type Transformer = Contract<TransformerData>;
 
 // TS-TODO: Transformers should be a default model and included in this module
 export const evaluate = async ({
@@ -55,7 +48,7 @@ export const evaluate = async ({
 		oldContract?.data?.$transformer?.artifactReady !== readyNow;
 
 	await Promise.all(
-		transformers.map(async (transformer: Transformer) => {
+		transformers.map(async (transformer: TransformerContract) => {
 			if (!transformer.data.inputFilter) {
 				return;
 			}
@@ -154,7 +147,7 @@ async function getTransformerActor(
 			limit?: number;
 		},
 	) => Promise<Contract[]>,
-	transformer: Transformer,
+	transformer: TransformerContract,
 ) {
 	// The transformer should be run on behalf of the actor that owns the
 	// transformer

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -184,3 +184,29 @@ export interface ScheduledActionContractDefinition
 
 export interface ScheduledActionContract
 	extends Contract<ScheduledActionData> {}
+
+export interface TransformerData {
+	data: {
+		requirements: {
+			os?: string;
+			architecture?: string;
+			[k: string]: unknown;
+		};
+		inputFilter: {
+			[k: string]: unknown;
+		};
+		workerFilter: {
+			[k: string]: unknown;
+		};
+		[k: string]: unknown;
+	};
+	[k: string]: unknown;
+}
+
+export interface TransformerContractDefinition
+	extends Omit<ContractDefinition, 'data'>,
+		TransformerData {}
+
+export interface TransformerContract
+	extends Omit<Contract, 'data'>,
+		TransformerData {}

--- a/test/integration/insert-card.spec.ts
+++ b/test/integration/insert-card.spec.ts
@@ -6,8 +6,8 @@ import { strict as assert } from 'assert';
 import { Kernel, testUtils as autumndbTestUtils } from 'autumndb';
 import _ from 'lodash';
 import {
-	ActionDefinition,
 	testUtils,
+	PluginDefinition,
 	TriggeredActionContract,
 	TriggeredActionData,
 } from '../../lib';
@@ -16,29 +16,43 @@ import { actionCreateCard } from '../../lib/actions/action-create-card';
 let ctx: testUtils.TestContext;
 
 beforeAll(async () => {
-	const actionTestOriginator: ActionDefinition = {
-		handler: async (
-			session: string,
-			handlerCtx: any,
-			contract: any,
-			request: any,
-		) => {
-			request.arguments.properties.data =
-				request.arguments.properties.data || {};
-			request.arguments.properties.data.originator = request.originator;
-			return actionCreateCard.handler(session, handlerCtx, contract, request);
-		},
-		contract: {
-			slug: 'action-test-originator',
+	const foobarPlugin = (): PluginDefinition => {
+		return {
+			slug: 'plugin-foobar',
+			name: 'Foobar Plugin',
 			version: '1.0.0',
-			type: actionCreateCard.contract.type,
-			name: actionCreateCard.contract.name,
-			data: actionCreateCard.contract.data,
-		},
+			actions: [
+				{
+					handler: async (
+						session: string,
+						handlerCtx: any,
+						contract: any,
+						request: any,
+					) => {
+						request.arguments.properties.data =
+							request.arguments.properties.data || {};
+						request.arguments.properties.data.originator = request.originator;
+						return actionCreateCard.handler(
+							session,
+							handlerCtx,
+							contract,
+							request,
+						);
+					},
+					contract: {
+						slug: 'action-test-originator',
+						version: '1.0.0',
+						type: actionCreateCard.contract.type,
+						name: actionCreateCard.contract.name,
+						data: actionCreateCard.contract.data,
+					},
+				},
+			],
+		};
 	};
 
 	ctx = await testUtils.newContext({
-		actions: [actionTestOriginator],
+		plugins: [foobarPlugin()],
 	});
 });
 


### PR DESCRIPTION
Update worker to be created with a list of plugins.
This means that all contracts provided by plugins
are inserted into the system when the worker starts.
Also allows us to add in the worker instance contract
update stream. A part of bringing the API codebase
into the worker.

Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

Testing with:
- https://github.com/product-os/jellyfish-plugin-default/pull/1079
- https://github.com/product-os/jellyfish-plugin-product-os/pull/776
- https://github.com/product-os/jellyfish-plugin-channels/pull/607
- https://github.com/product-os/jellyfish-plugin-typeform/pull/834
- https://github.com/product-os/jellyfish-plugin-flowdock/pull/408
- https://github.com/product-os/jellyfish-plugin-balena-api/pull/412
- https://github.com/product-os/jellyfish-plugin-outreach/pull/574
- https://github.com/product-os/jellyfish-plugin-github/pull/807
- https://github.com/product-os/jellyfish-plugin-discourse/pull/404
- https://github.com/product-os/jellyfish-plugin-front/pull/449
- https://github.com/product-os/jellyfish/pull/8429