### PR TITLE
Add slug to integration definition

### DIFF
--- a/lib/plugin/helpers.ts
+++ b/lib/plugin/helpers.ts
@@ -63,6 +63,8 @@ class TestIntegration implements Integration {
 
 const integrationDefinitionFor = (slug: string): IntegrationDefinition => {
 	return {
+		slug,
+
 		initialize: async () => new TestIntegration(slug),
 
 		isEventValid: (

--- a/lib/sync/index.ts
+++ b/lib/sync/index.ts
@@ -379,7 +379,6 @@ export class Sync {
 			actor: options.actor,
 			origin: options.origin,
 			defaultUser: options.defaultUser,
-			provider: name,
 			token,
 			context,
 		});
@@ -442,7 +441,6 @@ export class Sync {
 				actor: options.actor,
 				origin: options.origin,
 				defaultUser: options.defaultUser,
-				provider: name,
 				token,
 				context,
 			});
@@ -524,7 +522,6 @@ export class Sync {
 			},
 			{
 				actor: options.actor,
-				provider: name,
 				origin: '',
 				defaultUser: '',
 				context,

--- a/lib/sync/instance.spec.ts
+++ b/lib/sync/instance.spec.ts
@@ -97,6 +97,8 @@ afterAll(() => {
 });
 
 const oAuthTokenRefreshTestIntegration = {
+	slug: 'balena-cloud',
+
 	OAUTH_BASE_URL: 'https://api.balena-cloud.com',
 	OAUTH_SCOPES: ['users'],
 
@@ -198,7 +200,6 @@ describe('instance', () => {
 				actor: 'foo',
 				defaultUser: 'bar',
 				origin: 'https://jel.ly.fish/oauth/balena-cloud',
-				provider: 'balena-cloud',
 				context: {
 					log: {
 						info: _.noop,
@@ -291,7 +292,6 @@ describe('instance', () => {
 				origin: 'https://jel.ly.fish/oauth/balena-cloud',
 				actor: 'foo',
 				defaultUser: 'jellysync',
-				provider: 'balena-cloud',
 				context: {
 					log: {
 						info: _.noop,
@@ -406,7 +406,6 @@ describe('instance', () => {
 				actor: 'foo',
 				defaultUser: 'bar',
 				origin: 'https://jel.ly.fish/oauth/balena-cloud',
-				provider: 'balena-cloud',
 				context: {
 					log: {
 						info: _.noop,
@@ -499,7 +498,6 @@ describe('instance', () => {
 				actor: 'foobar',
 				origin: 'https://jel.ly.fish/oauth/balena-cloud',
 				defaultUser: 'jellysync',
-				provider: 'balena-cloud',
 				context: {
 					log: {
 						info: _.noop,
@@ -634,7 +632,6 @@ describe('instance', () => {
 				{
 					actor: 'foo',
 					origin: 'https://jel.ly.fish/oauth/balena-cloud',
-					provider: 'balena-cloud',
 					defaultUser: 'foobar',
 					context: {
 						log: {

--- a/lib/sync/instance.ts
+++ b/lib/sync/instance.ts
@@ -261,12 +261,12 @@ export const run = async (
 
 				options.context.log.info('Sync: Getting OAuth user', {
 					actor,
-					provider: options.provider,
+					provider: integration.slug,
 					defaultUser: options.defaultUser,
 				});
 				const userContract = await getOAuthUser(
 					options.context,
-					options.provider,
+					integration.slug,
 					actor,
 					{
 						defaultUser: options.defaultUser,
@@ -276,7 +276,7 @@ export const run = async (
 					id: userContract.id,
 				});
 
-				const tokenPath = ['data', 'oauth', options.provider];
+				const tokenPath = ['data', 'oauth', integration.slug];
 				const tokenData = _.get(userContract, tokenPath);
 				if (tokenData) {
 					_.set(
@@ -291,7 +291,7 @@ export const run = async (
 				// Lets try refreshing the token and retry if so
 				if (result.code === 401 && tokenData) {
 					options.context.log.info('Refreshing OAuth token', {
-						provider: options.provider,
+						provider: integration.slug,
 						user: userContract.slug,
 						origin: options.origin,
 						appId: token.appId,

--- a/lib/sync/pipeline.ts
+++ b/lib/sync/pipeline.ts
@@ -39,7 +39,6 @@ const runIntegration = async (
 			actor: options.actor,
 			origin: options.origin,
 			defaultUser: options.defaultUser,
-			provider: options.provider,
 			context: options.context,
 		},
 	);

--- a/lib/sync/types.ts
+++ b/lib/sync/types.ts
@@ -23,7 +23,6 @@ export interface PipelineOpts {
 	actor: string;
 	origin: string;
 	defaultUser: string;
-	provider: string;
 	token: any;
 	context: SyncActionContext;
 }
@@ -98,6 +97,8 @@ export interface IntegrationInitializationOptions {
 }
 
 export interface IntegrationDefinition {
+	slug: string;
+
 	OAUTH_BASE_URL?: string;
 	OAUTH_SCOPES?: string[];
 


### PR DESCRIPTION
- Remove extra parameter `provider` for running integration. Oauth credentials in user contract is stored in [`user.data.oauth[integration]`](https://github.com/product-os/jellyfish-worker/blob/6c93126aa385f5e0d5c242de14988383fdfca856/lib/sync/index.ts#L258-L295);
- Add slug to integration definition;

Change-type: major