### PR TITLE
Pass SyncActionContext to whoami()

### DIFF
--- a/lib/sync/index.ts
+++ b/lib/sync/index.ts
@@ -54,30 +54,34 @@ export class Sync {
 	 * @function
 	 * @public
 	 *
-	 * @param {Object} context - log context
+	 * @param {Object} syncActionContext - sync action context
 	 * @param {String} name - integration name
 	 * @param {String} credentials - access token for external provider api
 	 * @returns {Object} external user
 	 */
-	async whoami(logContext: LogContext, name: string, credentials: any) {
+	async whoami(
+		syncActionContext: syncContext.SyncActionContext,
+		name: string,
+		credentials: any,
+	) {
 		const integration = this.integrations[name];
 
 		assert.INTERNAL(
-			logContext,
+			syncActionContext,
 			!!integration,
 			errors.SyncNoCompatibleIntegration,
 			`There is no compatible integration for provider: ${name}`,
 		);
 
 		assert.INTERNAL(
-			logContext,
+			syncActionContext,
 			!!integration.whoami,
 			errors.SyncNoCompatibleIntegration,
 			`Integration for ${name} does not provide a whoami() function`,
 		);
 
 		strict.ok(integration.whoami);
-		return integration.whoami(logContext, credentials);
+		return integration.whoami(syncActionContext, credentials);
 	}
 
 	/**

--- a/lib/sync/sync-context.ts
+++ b/lib/sync/sync-context.ts
@@ -72,6 +72,7 @@ export const getActionContext = (
 	};
 
 	const contextObject = {
+		logContext,
 		log: {
 			warn: (message: string, data: any) => {
 				logger.warn(logContext, message, data);

--- a/lib/sync/types.ts
+++ b/lib/sync/types.ts
@@ -109,7 +109,10 @@ export interface IntegrationDefinition {
 		headers: Map<string>,
 	) => Promise<boolean> | boolean;
 
-	whoami?: (logContext: LogContext, credentials: any) => Promise<any>;
+	whoami?: (
+		syncActionContext: SyncActionContext,
+		credentials: any,
+	) => Promise<any>;
 
 	match?: (
 		context: SyncActionContext,


### PR DESCRIPTION
Pass an instance of SyncActionContext instead of
LogContext into the whoami() function to give
this function the ability to query the backend.

Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>