### PR TITLE
Switch to polling strategy for cached contracts

### DIFF
--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -353,9 +353,7 @@ export const newContext = async (
  * Deinitialize the worker.
  */
 export const destroyContext = async (context: TestContext) => {
-	await context.worker.consumer.cancel();
-	context.worker.contractsStream.removeAllListeners();
-	context.worker.contractsStream.close();
+	await context.worker.stop();
 	await autumndbTestUtils.destroyContext(context);
 };
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@balena/jellyfish-logger": "^5.1.2",
     "@balena/jellyfish-metrics": "^2.0.84",
     "@graphile/logger": "^0.2.0",
+    "@types/node": "^17.0.41",
     "autumndb": "^20.1.2",
     "axios": "^0.26.1",
     "bcrypt": "^5.0.1",

--- a/test/integration/index.spec.ts
+++ b/test/integration/index.spec.ts
@@ -2,6 +2,7 @@ import { TypeContract, UserContract } from '@balena/jellyfish-types/build/core';
 import { strict as assert } from 'assert';
 import { Kernel, testUtils as autumndbTestUtils } from 'autumndb';
 import _ from 'lodash';
+import { setTimeout as delay } from 'timers/promises';
 import {
 	ActionRequestContract,
 	ActionRequestData,
@@ -141,11 +142,7 @@ describe('.getId()', () => {
 		expect(worker1.getId()).not.toBe(worker3.getId());
 		expect(worker2.getId()).not.toBe(worker3.getId());
 
-		await Promise.all([
-			worker1.consumer.cancel(),
-			worker2.consumer.cancel(),
-			worker3.consumer.cancel(),
-		]);
+		await Promise.all([worker1.stop(), worker2.stop(), worker3.stop()]);
 	});
 });
 
@@ -174,7 +171,8 @@ describe('Worker', () => {
 		);
 		assert(contract);
 
-		// Wait for the stream to update the worker
+		// Wait for the polling mechanism to update the worker
+		await delay(15 * 1000);
 		await ctx.retry(
 			() => {
 				return ctx.worker.typeContracts[`${contract.slug}@${contract.version}`];
@@ -218,7 +216,8 @@ describe('Worker', () => {
 		);
 		assert(contract);
 
-		// Wait for the stream to update the worker
+		// Wait for the polling mechanism to update the worker
+		await delay(15 * 1000);
 		await ctx.retry(
 			() => {
 				return _.find(ctx.worker.triggers, { id: contract.id });
@@ -252,7 +251,8 @@ describe('Worker', () => {
 			},
 		);
 
-		// Will fail until the stream updates the worker
+		// Wait for the polling mechanism to update the worker
+		await delay(15 * 1000);
 		const match = (transformer: TransformerContract) => {
 			return _.includes(transformerSlugs, transformer.slug);
 		};
@@ -307,7 +307,8 @@ describe('Worker', () => {
 		);
 		assert(contract);
 
-		// Wait for the stream to update the worker
+		// Wait for the polling mechanism to update the worker
+		await delay(15 * 1000);
 		await ctx.retry(
 			() => {
 				return _.find(ctx.worker.triggers, (item: TriggeredActionContract) => {

--- a/test/integration/transformers.spec.ts
+++ b/test/integration/transformers.spec.ts
@@ -66,6 +66,7 @@ describe('transformers', () => {
 			(matches: TransformerContract[]) => {
 				return matches.length === 2;
 			},
+			30,
 		);
 
 		// Insert a new contract
@@ -226,6 +227,7 @@ describe('transformers', () => {
 			(matches: TransformerContract[]) => {
 				return matches.length === 2;
 			},
+			30,
 		);
 
 		// Insert a new contract
@@ -396,6 +398,7 @@ describe('transformers', () => {
 			(matches: TransformerContract[]) => {
 				return matches.length === 2;
 			},
+			30,
 		);
 
 		// Insert a new contract
@@ -567,6 +570,7 @@ describe('transformers', () => {
 			(matches: TransformerContract[]) => {
 				return matches.length === 2;
 			},
+			30,
 		);
 
 		// Insert a new contract
@@ -687,6 +691,7 @@ describe('transformers', () => {
 			(matches: TransformerContract[]) => {
 				return matches.length === 2;
 			},
+			30,
 		);
 
 		// Insert a new contract
@@ -828,6 +833,7 @@ describe('transformers', () => {
 			(matches: TransformerContract[]) => {
 				return matches.length === 2;
 			},
+			30,
 		);
 
 		// Insert a new contract
@@ -998,6 +1004,7 @@ describe('transformers', () => {
 			(matches: TransformerContract[]) => {
 				return matches.length === 2;
 			},
+			30,
 		);
 
 		// Insert a new contract


### PR DESCRIPTION
Because updates to transformers, triggers and types are infrequent,
streaming these contracts generates a lot of overhead. Switching to
a slow polling strategy should reduce load on the DB.
This change also adds a `stop()` method that can safely shutdown the
worker, waiting for jobs to finish and stopping the polling.

Change-type: major
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

---

Testing with:
- https://github.com/product-os/jellyfish-plugin-default/pull/1198
- https://github.com/product-os/jellyfish-plugin-channels/pull/681
- https://github.com/product-os/jellyfish-plugin-flowdock/pull/503
- https://github.com/product-os/jellyfish-plugin-typeform/pull/933