### PR TITLE
Improve performance of task matchmaking trigger

### DIFF
--- a/lib/contracts/triggered-action-matchmake-task.ts
+++ b/lib/contracts/triggered-action-matchmake-task.ts
@@ -7,7 +7,6 @@ export const triggeredActionMatchmakeTask: ContractDefinition = {
 	name: 'Triggered action for matchmaking tasks to agents',
 	markers: [],
 	data: {
-		schedule: 'enqueue',
 		filter: {
 			type: 'object',
 			required: ['active', 'type', 'data'],
@@ -45,6 +44,10 @@ export const triggeredActionMatchmakeTask: ContractDefinition = {
 					properties: {
 						id: {
 							type: 'string',
+						},
+						type: {
+							type: 'string',
+							const: 'task@1.0.0',
 						},
 					},
 				},


### PR DESCRIPTION
By specifying the contract type that the trigger expands, we can use
heuristics to reduce unnecessary queries to the DB.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>