### PR TITLE
async triggers

### DIFF
--- a/lib/actions/action-evaluate-triggers.ts
+++ b/lib/actions/action-evaluate-triggers.ts
@@ -1,0 +1,86 @@
+import { getLogger } from '@balena/jellyfish-logger';
+import type { ActionDefinition } from '../plugin';
+import _ from 'lodash';
+
+const logger = getLogger(__filename);
+
+const handler: ActionDefinition['handler'] = async (
+	session,
+	context,
+	card,
+	request,
+) => {
+	logger.debug(
+		request.logContext,
+		`action-evaluate-triggers handler ${session} ${context} ${card} ${request}`,
+		{},
+	);
+	await context.executeAsyncTriggers(
+		request.arguments.currentContract,
+		request.arguments.insertedContract,
+		request.arguments.options,
+		request.arguments.currentTime,
+		request.arguments.session,
+	);
+
+	return null;
+};
+
+export const actionEvaluateTriggers: ActionDefinition = {
+	handler,
+	contract: {
+		slug: 'action-evaluate-triggers',
+		version: '1.0.0',
+		type: 'action@1.0.0',
+		name: 'Evaluate triggers',
+		data: {
+			arguments: {
+				session: {
+					type: 'string',
+				},
+				currentTime: {
+					type: 'string',
+				},
+				currentContract: {
+					anyOf: [
+						{
+							type: 'object',
+						},
+						{
+							type: 'null',
+						},
+					],
+				},
+				insertedContract: {
+					type: 'object',
+				},
+				options: {
+					type: 'object',
+					properties: {
+						actor: {
+							type: ['string', 'null'],
+						},
+						originator: {
+							type: ['string', 'null'],
+						},
+						attachEvents: {
+							type: 'boolean',
+						},
+						timestamp: {
+							type: ['string', 'null'],
+						},
+						reason: {
+							type: ['string', 'null'],
+						},
+						eventType: {
+							type: ['object', 'string', 'null'],
+						},
+						eventPayload: {
+							type: ['object', 'array', 'number', 'string', 'null'],
+						},
+					},
+				},
+			},
+		},
+	},
+};

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -4,6 +4,7 @@ import { actionCreateCard } from './action-create-card';
 import { actionCreateEvent } from './action-create-event';
 import { actionCreateSession } from './action-create-session';
 import { actionCreateUser } from './action-create-user';
+import { actionEvaluateTriggers } from './action-evaluate-triggers';
 import { actionMatchMakeTask } from './action-matchmake-task';
 import { actionSetAdd } from './action-set-add';
 import { actionUpdateCard } from './action-update-card';
@@ -14,6 +15,7 @@ export const actions: ActionDefinition[] = [
 	actionCreateEvent,
 	actionCreateSession,
 	actionCreateUser,
+	actionEvaluateTriggers,
 	actionMatchMakeTask,
 	actionSetAdd,
 	actionUpdateCard,

--- a/lib/transformers.ts
+++ b/lib/transformers.ts
@@ -35,7 +35,11 @@ export const evaluate = async ({
 	query,
 	executeAndAwaitAction,
 }: EvaluateOptions): Promise<null> => {
-	if (!transformers || !Array.isArray(transformers)) {
+	if (
+		!transformers ||
+		!Array.isArray(transformers) ||
+		transformers.length === 0
+	) {
 		logger.info(logContext, 'No transformers');
 		return null;
 	}
@@ -184,16 +188,20 @@ export const evaluate = async ({
 	);
 
 	if (!results.includes(true)) {
-		logger.info(logContext, 'Did not execute any transformers', {
-			newContract: {
-				id: newContract.id,
-				type: newContract.type,
+		logger.info(
+			logContext,
+			`Did not execute any of ${transformers.length} transformers`,
+			{
+				newContract: {
+					id: newContract.id,
+					type: newContract.type,
+				},
+				oldContract: {
+					id: oldContract?.id,
+					type: oldContract?.type,
+				},
 			},
-			oldContract: {
-				id: oldContract?.id,
-				type: oldContract?.type,
-			},
-		});
+		);
 	}
 	return null;
 };

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -147,6 +147,29 @@ export interface WorkerContext {
 	cards: {
 		[slug: string]: ContractDefinition<ContractData>;
 	};
+	executeAsyncTriggers: (
+		currentContract: Contract<
+			ContractData,
+			{ [key: string]: Array<Contract<ContractData, any>> }
+		> | null,
+		insertedContract:
+			| TypeContract
+			| Contract<
+					ContractData,
+					{ [key: string]: Array<Contract<ContractData, any>> }
+			  >,
+		options: {
+			actor: any;
+			originator: any;
+			attachEvents: any;
+			timestamp: string | number | Date;
+			reason: any;
+			eventType: any;
+			eventPayload: any;
+		},
+		currentTime: Date,
+		session: string,
+	) => Promise<void>;
 }
 
 export interface EnqueueOptions {

--- a/test/integration/execute.spec.ts
+++ b/test/integration/execute.spec.ts
@@ -182,6 +182,7 @@ describe('.execute()', () => {
 		assert(typeContract !== null);
 		assert(actionContract !== null);
 
+		ctx.worker.disableDataCache();
 		const command = autumndbTestUtils.generateRandomSlug();
 		ctx.worker.upsertTrigger(
 			ctx.logContext,
@@ -421,6 +422,7 @@ describe('.execute()', () => {
 		assert(typeContract !== null);
 		assert(actionContract !== null);
 
+		ctx.worker.disableDataCache();
 		const command = autumndbTestUtils.generateRandomSlug();
 		ctx.worker.upsertTrigger(
 			ctx.logContext,
@@ -1228,6 +1230,7 @@ describe('.execute()', () => {
 		const user = await ctx.createUser(autumndbTestUtils.generateRandomId());
 		const session = await ctx.createSession(user);
 
+		ctx.worker.disableDataCache();
 		const foo = autumndbTestUtils.generateRandomSlug();
 		ctx.worker.upsertTrigger(
 			ctx.logContext,


### PR DESCRIPTION
Description: See https://jel.ly.fish/improvement-jip-improve-performance-triggers-47b1dc8/345ddc34-dbb4-4d50-aebf-927f111a9dc1

Pending

- [x] In this version the priority is set by enqueuing with a parameter on the producer. An alternative would be to set the priority on the action object, and read that property on the queue producer. This comes from "Allow priority to be set on action requests" and "This would probably mean reading a priority value from the action-request contract and passing it into the queue method." which Lucian mentioned in the initial description.

- [x] Validate: "Action requests for the processing triggers should not be readable by users as they may contain data from contracts they can't read". Not sure what to check for here
- [x] Create an integration test: a) confirm priorities b) that an `action-evaluate-triggers` is created when I insert a card

Fixed item 1 by passing the property as an option