### PR TITLE
Bring in channels

### DIFF
--- a/lib/actions/action-bootstrap-channel.ts
+++ b/lib/actions/action-bootstrap-channel.ts
@@ -1,0 +1,225 @@
+import { getLogger } from '@balena/jellyfish-logger';
+import type {
+	ContractDefinition,
+	TypeContract,
+} from '@balena/jellyfish-types/build/core';
+import { strict as assert } from 'assert';
+import _ from 'lodash';
+import slugify from 'slugify';
+import type { ActionDefinition } from '../plugin';
+import type { ChannelContract } from '../types';
+
+const logger = getLogger(__filename);
+
+const capitalizeFirst = (str: string): string => {
+	return `${str.charAt(0).toUpperCase()}${str.slice(1)}`;
+};
+
+// TS-TODO: the return type should be Partial<ViewContractDefinition>
+const commonView = (
+	channelContract: ChannelContract,
+): Partial<ContractDefinition> => {
+	return {
+		version: '1.0.0',
+		type: 'view@1.0.0',
+		markers: ['org-balena'],
+		tags: [],
+		active: true,
+		data: {
+			namespace: channelContract.name,
+		},
+		requires: [],
+		capabilities: [],
+	};
+};
+
+const createViewAll = (
+	channelContract: ChannelContract,
+): Partial<ContractDefinition> => {
+	const channelName = channelContract.name!.toLowerCase();
+	return _.merge({}, commonView(channelContract), {
+		slug: `view-all-${slugify(channelName)}`,
+		name: `All ${channelName}`,
+		data: {
+			allOf: [channelContract.data.filter],
+		},
+	});
+};
+
+const createOwnedByMeView = (
+	channelContract: ChannelContract,
+): Partial<ContractDefinition> => {
+	const channelName = channelContract.name!.toLowerCase();
+	return _.merge({}, commonView(channelContract), {
+		slug: `view-${slugify(channelName)}-owned-by-me`,
+		name: `${capitalizeFirst(channelName)} owned by me`,
+		data: {
+			allOf: [
+				channelContract.data.filter,
+				{
+					name: 'Contracts owned by me',
+					schema: {
+						type: 'object',
+						$$links: {
+							'is owned by': {
+								type: 'object',
+								properties: {
+									type: {
+										const: 'user@1.0.0',
+									},
+									id: {
+										const: {
+											$eval: 'user.id',
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			],
+		},
+	});
+};
+
+const createUnownedView = (
+	channelContract: ChannelContract,
+): Partial<ContractDefinition> => {
+	const channelName = channelContract.name!.toLowerCase();
+	return _.merge({}, commonView(channelContract), {
+		slug: `view-unowned-${slugify(channelName)}`,
+		name: `Unowned ${channelName}`,
+		data: {
+			allOf: [
+				channelContract.data.filter,
+				{
+					name: 'Unowned contracts',
+					schema: {
+						type: 'object',
+						not: {
+							$$links: {
+								'is owned by': {
+									properties: {
+										type: {
+											const: 'user@1.0.0',
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			],
+		},
+	});
+};
+
+// TS-TODO: ActionFile should be generic so we can specify the contract data type
+const handler: ActionDefinition['handler'] = async (
+	session,
+	context,
+	contract,
+	request,
+) => {
+	logger.info(request.logContext, `Bootstrapping channel '${contract.slug}'`);
+
+	const viewTypeContract = await context.getCardBySlug(session, 'view@latest');
+	assert(!!viewTypeContract, 'View type contract not found');
+
+	const linkTypeContract = await context.getCardBySlug(session, 'link@latest');
+	assert(!!linkTypeContract, 'Link type contract not found');
+
+	// Create views based on the channel's base filter
+	const views = [
+		createViewAll(contract as ChannelContract),
+		createOwnedByMeView(contract as ChannelContract),
+		createUnownedView(contract as ChannelContract),
+	];
+
+	await Promise.all(
+		views.map(async (viewContractBase: any) => {
+			// Save the view contract
+			let viewContract = await context.replaceCard(
+				session,
+				viewTypeContract as TypeContract,
+				{
+					timestamp: request.timestamp,
+					actor: request.actor,
+					originator: request.originator,
+					attachEvents: true,
+				},
+				viewContractBase,
+			);
+
+			// If the view contract already exists and no changes were made, replaceCard returns null,
+			// so we just fetch the contract by slug.
+			if (viewContract === null) {
+				viewContract = await context.getCardBySlug(
+					session,
+					`${viewContractBase.slug}@${viewContractBase.version}`,
+				);
+			}
+			assert(!!viewContract, 'View contract is null');
+
+			// And create a link contract between the view and the channel
+			return context.replaceCard(
+				session,
+				linkTypeContract as TypeContract,
+				{
+					timestamp: request.timestamp,
+					actor: request.actor,
+					originator: request.originator,
+					attachEvents: false,
+				},
+				{
+					slug: `link-${viewContract.id}-is-attached-to-${contract.id}`,
+					type: 'link@1.0.0',
+					name: 'is attached to',
+					data: {
+						inverseName: 'has attached element',
+						from: {
+							id: viewContract.id,
+							type: viewContract.type,
+						},
+						to: {
+							id: contract.id,
+							type: contract.type,
+						},
+					},
+				},
+			);
+		}),
+	);
+
+	const result = contract;
+
+	return {
+		id: result.id,
+		type: result.type,
+		version: result.version,
+		slug: result.slug,
+	};
+};
+
+export const actionBootstrapChannel: ActionDefinition = {
+	handler,
+	contract: {
+		slug: 'action-bootstrap-channel',
+		version: '1.0.0',
+		type: 'action@1.0.0',
+		name: 'Bootstrap a channel',
+		data: {
+			filter: {
+				type: 'object',
+				properties: {
+					type: {
+						type: 'string',
+						const: 'channel@1.0.0',
+					},
+				},
+				required: ['type'],
+			},
+			arguments: {},
+		},
+	},
+};

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -1,4 +1,5 @@
 import type { ActionDefinition } from '../plugin';
+import { actionBootstrapChannel } from './action-bootstrap-channel';
 import { actionCreateCard } from './action-create-card';
 import { actionCreateEvent } from './action-create-event';
 import { actionCreateSession } from './action-create-session';
@@ -8,6 +9,7 @@ import { actionSetAdd } from './action-set-add';
 import { actionUpdateCard } from './action-update-card';
 
 export const actions: ActionDefinition[] = [
+	actionBootstrapChannel,
 	actionCreateCard,
 	actionCreateEvent,
 	actionCreateSession,

--- a/lib/contracts/agent-channel-settings.ts
+++ b/lib/contracts/agent-channel-settings.ts
@@ -1,0 +1,25 @@
+import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+
+export const agentChannelSettings: ContractDefinition = {
+	slug: 'agent-channel-settings',
+	name: 'Agent Channel Settings',
+	type: 'type@1.0.0',
+	data: {
+		schema: {
+			type: 'object',
+			required: ['data'],
+			properties: {
+				data: {
+					type: 'object',
+					properties: {
+						optIn: {
+							description: 'Opt-in to own the next available channel contract',
+							type: 'boolean',
+							default: false,
+						},
+					},
+				},
+			},
+		},
+	},
+};

--- a/lib/contracts/channel.ts
+++ b/lib/contracts/channel.ts
@@ -1,0 +1,29 @@
+import type {
+	ContractDefinition,
+	TypeData,
+} from '@balena/jellyfish-types/build/core';
+
+export const channel: ContractDefinition<TypeData> = {
+	slug: 'channel',
+	name: 'Channel',
+	type: 'type@1.0.0',
+	data: {
+		schema: {
+			type: 'object',
+			required: ['data'],
+			properties: {
+				data: {
+					type: 'object',
+					required: ['filter'],
+					properties: {
+						filter: {
+							description:
+								'Contracts matching this filter will be handled by the channel',
+							type: 'object',
+						},
+					},
+				},
+			},
+		},
+	},
+};

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -1,4 +1,6 @@
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+import { agentChannelSettings } from './agent-channel-settings';
+import { channel } from './channel';
 import { contact } from './contact';
 import { create } from './create';
 import { genericSource } from './generic-source';
@@ -6,6 +8,8 @@ import { image } from './image';
 import { imageSource } from './image-source';
 import { oauthProvider } from './oauth-provider';
 import { relationshipAnyIsCreatorOfAny } from './relationship-any-is-creator-of-any';
+import { relationshipChannelHasAgentUser } from './relationship-channel-has-agent-user';
+import { relationshipChannelHasSettingsAgentChannelSettings } from './relationship-channel-has-settings-agent-channel-settings';
 import { relationshipContactHasBackupOwnerUser } from './relationship-contact-has-backup-owner-user';
 import { relationshipContactIsAttachedToUser } from './relationship-contact-is-attached-to-user';
 import { relationshipContactIsOwnedByUser } from './relationship-contact-is-owned-by-user';
@@ -17,7 +21,9 @@ import { relationshipTransformerGeneratedTask } from './relationship-transformer
 import { relationshipTransformerWorkerOwnsTask } from './relationship-transformer-worker-owns-task';
 import { relationshipUpdateIsAttachedToAny } from './relationship-update-is-attached-to-any';
 import { relationshipUserHasAttachedContactContact } from './relationship-user-has-attached-contact-contact';
+import { relationshipUserHasSettingsAgentChannelSettings } from './relationship-user-has-settings-agent-channel-settings';
 import { relationshipUserHasSettingsWorkingHours } from './relationship-user-has-settings-working-hours';
+import { relationshipViewIsAttachedToChannel } from './relationship-view-is-attached-to-channel';
 import { roleTransformerWorker } from './role-transformer-worker';
 import { scheduledAction } from './scheduled-action';
 import { serviceSource } from './service-source';
@@ -25,6 +31,7 @@ import { task } from './task';
 import { transformer } from './transformer';
 import { transformerWorker } from './transformer-worker';
 import { triggeredAction } from './triggered-action';
+import { triggeredActionBootstrapChannel } from './triggered-action-bootstrap-channel';
 import { triggeredActionMatchmakeTask } from './triggered-action-matchmake-task';
 import { triggeredActionMergeDraftVersion } from './triggered-action-merge-draft-version';
 import { update } from './update';
@@ -36,12 +43,16 @@ import { viewScheduledActions } from './view-scheduled-actions';
 import { workingHours } from './working-hours';
 
 export const contracts: ContractDefinition[] = [
+	agentChannelSettings,
+	channel,
 	contact,
 	create,
 	genericSource,
 	image,
 	imageSource,
 	relationshipAnyIsCreatorOfAny,
+	relationshipChannelHasAgentUser,
+	relationshipChannelHasSettingsAgentChannelSettings,
 	relationshipContactHasBackupOwnerUser,
 	relationshipContactIsAttachedToUser,
 	relationshipContactIsOwnedByUser,
@@ -53,7 +64,9 @@ export const contracts: ContractDefinition[] = [
 	relationshipTransformerWorkerOwnsTask,
 	relationshipUpdateIsAttachedToAny,
 	relationshipUserHasAttachedContactContact,
+	relationshipUserHasSettingsAgentChannelSettings,
 	relationshipUserHasSettingsWorkingHours,
+	relationshipViewIsAttachedToChannel,
 	oauthProvider,
 	roleTransformerWorker,
 	scheduledAction,
@@ -62,6 +75,7 @@ export const contracts: ContractDefinition[] = [
 	transformer,
 	transformerWorker,
 	triggeredAction,
+	triggeredActionBootstrapChannel,
 	triggeredActionMatchmakeTask,
 	triggeredActionMergeDraftVersion,
 	update,

--- a/lib/contracts/relationship-channel-has-agent-user.ts
+++ b/lib/contracts/relationship-channel-has-agent-user.ts
@@ -1,0 +1,18 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipChannelHasAgentUser: RelationshipContractDefinition = {
+	slug: 'relationship-channel-has-agent-user',
+	type: 'relationship@1.0.0',
+	name: 'has agent',
+	data: {
+		inverseName: 'is agent for',
+		title: 'User',
+		inverseTitle: 'Channel',
+		from: {
+			type: 'channel',
+		},
+		to: {
+			type: 'user',
+		},
+	},
+};

--- a/lib/contracts/relationship-channel-has-settings-agent-channel-settings.ts
+++ b/lib/contracts/relationship-channel-has-settings-agent-channel-settings.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipChannelHasSettingsAgentChannelSettings: RelationshipContractDefinition =
+	{
+		slug: 'relationship-channel-has-settings-agent-channel-settings',
+		type: 'relationship@1.0.0',
+		name: 'has settings',
+		data: {
+			inverseName: 'are settings for',
+			title: 'Agent channel settings',
+			inverseTitle: 'Channel',
+			from: {
+				type: 'channel',
+			},
+			to: {
+				type: 'agent-channel-settings',
+			},
+		},
+	};

--- a/lib/contracts/relationship-user-has-settings-agent-channel-settings.ts
+++ b/lib/contracts/relationship-user-has-settings-agent-channel-settings.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipUserHasSettingsAgentChannelSettings: RelationshipContractDefinition =
+	{
+		slug: 'relationship-user-has-settings-agent-channel-settings',
+		type: 'relationship@1.0.0',
+		name: 'has settings',
+		data: {
+			inverseName: 'are settings for',
+			title: 'Agent channel settings',
+			inverseTitle: 'User',
+			from: {
+				type: 'user',
+			},
+			to: {
+				type: 'agent-channel-settings',
+			},
+		},
+	};

--- a/lib/contracts/relationship-view-is-attached-to-channel.ts
+++ b/lib/contracts/relationship-view-is-attached-to-channel.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipViewIsAttachedToChannel: RelationshipContractDefinition =
+	{
+		slug: 'relationship-view-is-attached-to-channel',
+		type: 'relationship@1.0.0',
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached element',
+			title: 'View',
+			inverseTitle: 'Channel',
+			from: {
+				type: 'view',
+			},
+			to: {
+				type: 'channel',
+			},
+		},
+	};

--- a/lib/contracts/triggered-action-bootstrap-channel.ts
+++ b/lib/contracts/triggered-action-bootstrap-channel.ts
@@ -1,0 +1,49 @@
+import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+import { TriggeredActionData } from '../types';
+
+export const triggeredActionBootstrapChannel: ContractDefinition<TriggeredActionData> =
+	{
+		slug: 'triggered-action-bootstrap-channel',
+		type: 'triggered-action@1.0.0',
+		name: 'Triggered action for bootstrapping a channel',
+		markers: [],
+		data: {
+			schedule: 'enqueue',
+			filter: {
+				type: 'object',
+				required: ['active', 'type', 'data'],
+				properties: {
+					active: {
+						type: 'boolean',
+						const: true,
+					},
+					type: {
+						type: 'string',
+						enum: ['create@1.0.0', 'update@1.0.0'],
+					},
+					data: {
+						type: 'object',
+						required: ['payload'],
+						properties: {
+							payload: {
+								type: 'object',
+								required: ['slug', 'type'],
+								properties: {
+									slug: {
+										type: 'string',
+									},
+									type: {
+										type: 'string',
+										const: 'channel@1.0.0',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			action: 'action-bootstrap-channel@1.0.0',
+			target: '${source.data.payload.slug}@1.0.0',
+			arguments: {},
+		},
+	};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -181,3 +181,18 @@ export interface TransformerContractDefinition
 export interface TransformerContract
 	extends Omit<Contract, 'data'>,
 		TransformerData {}
+
+export interface ChannelData {
+	/**
+	 * Contracts matching this filter will be handled by the channel
+	 */
+	filter: {
+		[k: string]: unknown;
+	};
+	[k: string]: unknown;
+}
+
+export interface ChannelContractDefinition
+	extends ContractDefinition<ChannelData> {}
+
+export interface ChannelContract extends Contract<ChannelData> {}

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "semver": "^7.3.7",
     "serialize-error": "8.1.0",
     "skhema": "^6.0.6",
+    "slugify": "^1.6.5",
     "typed-error": "^3.2.1",
     "uuid": "^8.3.2"
   },


### PR DESCRIPTION
Bring in all contracts and actions defined by plugin-channels

Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

This is needed for support v2 matchmaking as its logic needs to be able to reference agents' channel settings (opt-in etc). Also, channels should just be a first class citizen and not defined in a plugin. If/when this is merged, we can stop using and archive `jellyfish-plugin-channels`.