### PR TITLE
Add working-hours override contract

### DIFF
--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -34,6 +34,7 @@ import { viewAllTransformers } from './view-all-transformers';
 import { viewAllViews } from './view-all-views';
 import { viewScheduledActions } from './view-scheduled-actions';
 import { workingHours } from './working-hours';
+import { workingHoursOverride } from './working-hours-override';
 
 export const contracts: ContractDefinition[] = [
 	contact,
@@ -71,4 +72,5 @@ export const contracts: ContractDefinition[] = [
 	viewAllViews,
 	viewScheduledActions,
 	workingHours,
+	workingHoursOverride,
 ];

--- a/lib/contracts/relationship-user-has-settings-working-hours-override.ts
+++ b/lib/contracts/relationship-user-has-settings-working-hours-override.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipUserHasSettingsWorkingHoursOverride: RelationshipContractDefinition =
+	{
+		slug: 'relationship-user-has-settings-working-hours-override',
+		type: 'relationship@1.0.0',
+		name: 'has settings',
+		data: {
+			inverseName: 'are settings for',
+			title: 'Working hours override',
+			inverseTitle: 'User',
+			from: {
+				type: 'user',
+			},
+			to: {
+				type: 'working-hours-override',
+			},
+		},
+	};

--- a/lib/contracts/working-hours-override.ts
+++ b/lib/contracts/working-hours-override.ts
@@ -1,0 +1,44 @@
+import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+import { asTimeZone } from './mixins';
+import { timeSlots } from './working-hours';
+
+export const workingHoursOverride: ContractDefinition = {
+	slug: 'working-hours',
+	type: 'type@1.0.0',
+	name: 'Working hours',
+	data: {
+		schema: {
+			type: 'object',
+			properties: {
+				slug: {
+					type: 'string',
+					pattern: '^working-hours-[a-z0-9-]+$',
+				},
+				data: {
+					type: 'object',
+					required: ['timeZone', 'startDate', 'endDate', 'timeSlots'],
+					properties: {
+						timeZone: {
+							title: 'Time zone',
+							...asTimeZone(),
+						},
+						startDate: {
+							title: 'Start date',
+							type: 'string',
+							format: 'date-time',
+						},
+						endDate: {
+							title: 'End date',
+							type: 'string',
+							format: 'date-time',
+						},
+						timeSlots: {
+							title: 'Preferred working hours',
+							...timeSlots(),
+						},
+					},
+				},
+			},
+		},
+	},
+};

--- a/lib/contracts/working-hours.ts
+++ b/lib/contracts/working-hours.ts
@@ -18,7 +18,7 @@ export function asTimeSlot() {
 	return slot;
 }
 
-function timeSlots() {
+export function timeSlots() {
 	const properties: any = {};
 	for (const day of [
 		'Monday',
@@ -75,21 +75,10 @@ export const workingHours: ContractDefinition = {
 				},
 				data: {
 					type: 'object',
-					required: ['timeZone'],
 					properties: {
 						timeZone: {
 							title: 'Time zone',
 							...asTimeZone(),
-						},
-						startDate: {
-							title: 'Start date',
-							type: 'string',
-							format: 'date-time',
-						},
-						endDate: {
-							title: 'End date',
-							type: 'string',
-							format: 'date-time',
 						},
 						timeSlots: {
 							title: 'Preferred working hours',


### PR DESCRIPTION
The working-hours contract will act as a users default
preferred working hours. Overrides will override the default
working hours during a specified date range.

Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>