### PR TITLE
Add option to create links with action-create-card

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -690,6 +690,7 @@ export class Worker {
 				...CONTRACTS,
 				...self.getTypeContracts(),
 			},
+			relationships: self.kernel.getRelationships(),
 		};
 	}
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -7,6 +7,7 @@ import type {
 	ContractSummary,
 	JsonSchema,
 	Kernel,
+	RelationshipContract,
 	TypeContract,
 } from 'autumndb';
 import type { Operation } from 'fast-json-patch';
@@ -154,6 +155,7 @@ export interface WorkerContext {
 	cards: {
 		[slug: string]: ContractDefinition<ContractData>;
 	};
+	relationships: RelationshipContract[];
 }
 
 export interface EnqueueOptions {


### PR DESCRIPTION
Add the ability to create links between the contract being
created with action-create-card and other pre-existing contracts.

Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>