### PR TITLE
Fix bug where triggers are not recalculated when a relationship is added

### DIFF
--- a/lib/triggers.ts
+++ b/lib/triggers.ts
@@ -1,6 +1,6 @@
 import * as assert from '@balena/jellyfish-assert';
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
-import type { Contract, JsonSchema, Kernel, LinkContract } from 'autumndb';
+import { Contract, JsonSchema, Kernel, LinkContract } from 'autumndb';
 import jsone = require('json-e');
 import _ from 'lodash';
 import * as skhema from 'skhema';
@@ -113,6 +113,7 @@ export const matchesContract = async (
 		const linkContract: LinkContract = contract as LinkContract;
 		if (schema.$$links) {
 			const verb = Object.keys(schema.$$links)[0];
+
 			// If the link being inserted joins different types together
 			// than what is defined in the filter schema, we can use
 			// this as a heuristic to validate the trigger
@@ -176,11 +177,11 @@ export const matchesContract = async (
 	}
 
 	// Run the query
-	return _.first(
-		await kernel.query(logContext, session, schema, {
-			limit: 1,
-		}),
-	);
+	const [result] = await kernel.query(logContext, session, schema, {
+		limit: 1,
+	});
+
+	return result;
 };
 
 /**

--- a/test/integration/relationships.spec.ts
+++ b/test/integration/relationships.spec.ts
@@ -1,0 +1,184 @@
+import { TypeContract } from 'autumndb';
+import _ from 'lodash';
+import { setTimeout as delay } from 'timers/promises';
+import { testUtils } from '../../lib';
+
+let ctx: testUtils.TestContext;
+
+beforeAll(async () => {
+	ctx = await testUtils.newContext();
+});
+afterAll(() => {
+	return testUtils.destroyContext(ctx);
+});
+
+describe('Relationships', () => {
+	it('should calculate formula fields that use links when the relationship is inserted after the type', async () => {
+		const pilotType = await ctx.kernel.insertContract<TypeContract>(
+			ctx.logContext,
+			ctx.session,
+			{
+				type: 'type@1.0.0',
+				name: 'Pilot',
+				data: {
+					schema: {
+						type: 'object',
+						properties: {
+							data: {
+								type: 'object',
+								properties: {
+									planesFlown: {
+										type: 'number',
+										$$formula:
+											'contract.links["flies"] ? contract.links["flies"].length : 0',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		);
+
+		const planeType = await ctx.kernel.insertContract<TypeContract>(
+			ctx.logContext,
+			ctx.session,
+			{
+				type: 'type@1.0.0',
+				name: 'Plane',
+				data: {
+					schema: {
+						type: 'object',
+						properties: {},
+					},
+				},
+			},
+		);
+
+		// Now insert the relationship *after* the types have been created
+		const relationshipSlug = `relationship-${pilotType.slug}-flies-${planeType.slug}`;
+		await ctx.worker.insertCard(
+			ctx.logContext,
+			ctx.session,
+			ctx.worker.typeContracts['relationship@1.0.0'],
+			{
+				attachEvents: false,
+			},
+			{
+				slug: relationshipSlug,
+				type: 'relationship@1.0.0',
+				name: 'flies',
+				data: {
+					inverseName: 'is flown by',
+					title: 'Planes',
+					inverseTitle: 'Pilots',
+					from: {
+						type: pilotType.slug,
+					},
+					to: {
+						type: planeType.slug,
+					},
+				},
+			},
+		);
+
+		// Wait until the relationship is ready and avaiable in the kernel
+		while (true) {
+			await delay(500);
+			const relationships = ctx.kernel.getRelationships();
+			const found = relationships.find((r) => r.slug === relationshipSlug);
+			if (found) {
+				break;
+			}
+		}
+
+		// Create two subject contracts
+		const pilot = (await ctx.worker.insertCard(
+			ctx.logContext,
+			ctx.session,
+			pilotType,
+			{
+				timestamp: new Date().toISOString(),
+				actor: ctx.adminUserId,
+				attachEvents: false,
+				reason: null,
+			},
+			{
+				name: 'The pilot',
+			},
+		))!;
+		const plane = (await ctx.worker.insertCard(
+			ctx.logContext,
+			ctx.session,
+			planeType,
+			{
+				timestamp: new Date().toISOString(),
+				actor: ctx.adminUserId,
+				attachEvents: false,
+				reason: null,
+			},
+			{
+				name: 'The plane',
+			},
+		))!;
+
+		const linkType = ctx.worker.typeContracts['link@1.0.0'];
+
+		// Link the contracts together, which should result in the formula field being updated
+		await ctx.worker.insertCard(
+			ctx.logContext,
+			ctx.session,
+			linkType,
+			{
+				timestamp: new Date().toISOString(),
+				actor: ctx.adminUserId,
+				attachEvents: false,
+				reason: null,
+			},
+			{
+				name: 'flies',
+				data: {
+					inverseName: 'is flown by',
+					from: {
+						id: pilot.id,
+						slug: pilot.slug,
+						type: pilot.type,
+					},
+					to: {
+						id: plane.id,
+						slug: plane.slug,
+						type: plane.type,
+					},
+				},
+			},
+		);
+
+		await ctx.flushAll(ctx.session);
+
+		await delay(1000);
+
+		const result = await ctx.waitForMatch({
+			type: 'object',
+			additionalProperties: true,
+			required: ['id'],
+			properties: {
+				id: {
+					type: 'string',
+					const: pilot.id,
+				},
+				data: {
+					type: 'object',
+					required: ['planesFlown'],
+					properties: {
+						planesFlown: {
+							type: 'number',
+							const: 1,
+						},
+					},
+				},
+			},
+		});
+
+		expect(result.data.planesFlown).toBe(1);
+	});
+});


### PR DESCRIPTION
Fixes a bug where some materialized fields won't be calculated correctly.
What happens is that because we now use relationships to create the triggered actions, used to process materialized fields, if you insert the relationship after the type then the triggered action won't be generated.  The triggered actions only get generated when a type contract is inserted.
We need to changes this so that the formulas will get parsed and the appropriate triggered actions generated when a new relationship is inserted.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>