### PR TITLE
Sync: Don't auto-add an origin field to synced contracts

### DIFF
--- a/lib/sync/pipeline.ts
+++ b/lib/sync/pipeline.ts
@@ -153,23 +153,6 @@ export const importCards = async (
 
 			// Check if this is a JSONpatch or a slug-based upsert
 			if ('patch' in segment.card) {
-				// If the patch doesn't update the origin, add it now
-				if (
-					!_.find(segment.card.patch, {
-						path: '/data/origin',
-					})
-				) {
-					if (
-						options.origin &&
-						options.origin.type === 'external-event@1.0.0'
-					) {
-						segment.card.patch.push({
-							op: 'add',
-							path: '/data/origin',
-							value: `${options.origin.slug}@${options.origin.version}`,
-						});
-					}
-				}
 				finalObject = evaluateObject(
 					_.omit(segment.card, ['links']),
 					references,

--- a/lib/sync/sync-context.ts
+++ b/lib/sync/sync-context.ts
@@ -208,14 +208,8 @@ export const getActionContext = (
 				patch,
 			});
 
-			// If the only thing being updated is the origin, skip the update as
-			// it is a meaningless change.
-			// TODO: refactor the "origin" to be a link to the origin instead of hard coded value
-			if (
-				patch.length === 1 &&
-				patch[0].op === 'replace' &&
-				patch[0].path === '/data/origin'
-			) {
+			// Skip any meaningless changes
+			if (patch.length === 0) {
 				return current;
 			}
 


### PR DESCRIPTION
The origin field can be used to debug synced data, as it is a reference to the original webhook event.
However this is largely redundant since we have request tracing via the log context id, and in the future will generate more complete graphs when executing action requests.
Removing this logic simplifies the code, and prevents situations where
contracts are needlessly updated.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>