### PR TITLE
Only allow org members to add other users to an org

### DIFF
--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -145,6 +145,7 @@ import { triggeredActionIncrementTag } from './triggered-action-increment-tag';
 import { triggeredActionIntegrationImportEvent } from './triggered-action-integration-import-event';
 import { triggeredActionMatchmakeTask } from './triggered-action-matchmake-task';
 import { triggeredActionMergeDraftVersion } from './triggered-action-merge-draft-version';
+import { triggeredActionOrgCreationMembership } from './triggered-action-org-creation-membership';
 import { triggeredActionSetUserAvatar } from './triggered-action-set-user-avatar';
 import { triggeredActionSupportCompletedImprovementReopen } from './triggered-action-support-completed-improvement-reopen';
 import { triggeredActionSupportReopen } from './triggered-action-support-reopen';
@@ -336,6 +337,7 @@ export const contracts: ContractDefinition[] = [
 	triggeredActionIntegrationImportEvent,
 	triggeredActionMatchmakeTask,
 	triggeredActionMergeDraftVersion,
+	triggeredActionOrgCreationMembership,
 	triggeredActionSetUserAvatar,
 	triggeredActionSupportCompletedImprovementReopen,
 	triggeredActionSupportReopen,

--- a/lib/contracts/triggered-action-org-creation-membership.ts
+++ b/lib/contracts/triggered-action-org-creation-membership.ts
@@ -1,0 +1,46 @@
+import type { TriggeredActionContractDefinition } from '../types';
+
+export const triggeredActionOrgCreationMembership: TriggeredActionContractDefinition =
+	{
+		slug: 'triggered-action-org-creation-membership',
+		type: 'triggered-action@1.0.0',
+		name: 'Triggered action for automatically making an org creator a member',
+		markers: [],
+		data: {
+			filter: {
+				type: 'object',
+				properties: {
+					type: {
+						const: 'org@1.0.0',
+					},
+				},
+			},
+			action: 'action-create-card@1.0.0',
+			target: 'link@1.0.0',
+			arguments: {
+				reason: null,
+				properties: {
+					name: 'has member',
+					data: {
+						inverseName: 'is member of',
+						from: {
+							id: {
+								$eval: 'source.id',
+							},
+							type: {
+								$eval: 'source.type',
+							},
+						},
+						to: {
+							id: {
+								$eval: 'actor.id',
+							},
+							type: {
+								$eval: 'actor.type',
+							},
+						},
+					},
+				},
+			},
+		},
+	};

--- a/lib/triggers.ts
+++ b/lib/triggers.ts
@@ -25,6 +25,12 @@ interface CompileContext {
 		str: string,
 	) => RegExpMatchArray;
 	source?: Contract;
+	actor: {
+		id: string;
+		slug: string;
+		type: string;
+		version: string;
+	};
 }
 
 interface GetRequestOptions {
@@ -211,6 +217,12 @@ const compileTrigger = (
 	trigger: string | Record<any, any>,
 	contract: Contract | null,
 	currentDate: Date,
+	actor: {
+		id: string;
+		slug: string;
+		type: string;
+		version: string;
+	},
 ) => {
 	const context: CompileContext = {
 		timestamp: currentDate.toISOString(),
@@ -224,6 +236,7 @@ const compileTrigger = (
 			const match = str.match(regEx);
 			return match || [];
 		},
+		actor,
 	};
 
 	if (contract) {
@@ -305,13 +318,19 @@ export const getRequest = async (
 		},
 		newContractMatches || newContract,
 		options.currentDate,
+		{
+			id: options.session.actor.id,
+			type: options.session.actor.type,
+			slug: options.session.actor.slug,
+			version: options.session.actor.version,
+		},
 	);
 
 	if (!compiledTrigger) {
 		return null;
 	}
 
-	return {
+	const result = {
 		action: trigger.data.action,
 		arguments: compiledTrigger.arguments,
 		originator: trigger.id,
@@ -319,6 +338,8 @@ export const getRequest = async (
 		currentDate: options.currentDate,
 		card: compiledTrigger.target,
 	};
+
+	return result;
 };
 
 /**

--- a/test/integration/actions/action-send-first-time-login-link.spec.ts
+++ b/test/integration/actions/action-send-first-time-login-link.spec.ts
@@ -554,25 +554,29 @@ describe('action-send-first-time-login-link', () => {
 
 	test("throws an error when the first-time-login user does not belong to the requester's org", async () => {
 		nockRequest();
-		const newOrg = await ctx.createContract(
-			ctx.adminUserId,
-			ctx.session,
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
+		const userSession = { actor: user };
+		await ctx.createContract(
+			user.id,
+			userSession,
 			'org@1.0.0',
 			autumndbTestUtils.generateRandomSlug(),
 			{},
 		);
-		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
-		await ctx.createLinkThroughWorker(
-			ctx.adminUserId,
-			ctx.session,
-			user,
-			newOrg,
-			'is member of',
-			'has member',
+		const requester = await ctx.createUser(
+			autumndbTestUtils.generateRandomSlug(),
+		);
+		const requesterSession = { actor: requester };
+		await ctx.createContract(
+			requester.id,
+			requesterSession,
+			'org@1.0.0',
+			autumndbTestUtils.generateRandomSlug(),
+			{},
 		);
 
 		await expect(
-			ctx.processAction(ctx.session, {
+			ctx.processAction(requesterSession, {
 				type: 'action-request@1.0.0',
 				data: {
 					action: 'action-send-first-time-login-link@1.0.0',

--- a/test/integration/membership.spec.ts
+++ b/test/integration/membership.spec.ts
@@ -1,0 +1,218 @@
+import { testUtils as autumndbTestUtils } from 'autumndb';
+import { testUtils } from '../../lib';
+
+let ctx: testUtils.TestContext;
+
+beforeAll(async () => {
+	ctx = await testUtils.newContext();
+});
+
+afterAll(async () => {
+	await testUtils.destroyContext(ctx);
+});
+
+describe('membership', () => {
+	test('should automatically make org creator a member', async () => {
+		const user = await ctx.createUser(
+			autumndbTestUtils.generateRandomSlug(),
+			undefined,
+			['user-community'],
+		);
+
+		const session = { actor: user };
+
+		const org = await ctx.createContract(
+			user.id,
+			session,
+			'org@1.0.0',
+			'Closed org',
+			{},
+		);
+
+		const [member] = await ctx.kernel.query(
+			ctx.logContext,
+			session,
+			{
+				type: 'object',
+				properties: {
+					id: {
+						const: org.id,
+					},
+				},
+				$$links: {
+					'has member': {
+						type: 'object',
+						properties: {
+							id: {
+								const: user.id,
+							},
+						},
+					},
+				},
+			},
+			{
+				limit: 1,
+			},
+		);
+
+		expect(member).toBeDefined();
+	});
+
+	test('should allow creating a membership link if the user is a member', async () => {
+		const user = await ctx.createUser(
+			autumndbTestUtils.generateRandomSlug(),
+			undefined,
+			['user-community'],
+		);
+
+		const session = { actor: user };
+
+		// Create a closed org
+		const org = await ctx.createContract(
+			user.id,
+			session,
+			'org@1.0.0',
+			'Closed org',
+			{},
+		);
+
+		// Use the user session to try and invite themselves to the org by creating a link
+		const result = await ctx.createLinkThroughWorker(
+			user.id,
+			session,
+			org,
+			user,
+			'has member',
+			'is member of',
+		);
+
+		expect(result).toBeDefined();
+	});
+
+	test('should disallow creating a membership link if the user is not a member', async () => {
+		const user = await ctx.createUser(
+			autumndbTestUtils.generateRandomSlug(),
+			undefined,
+			['user-community'],
+		);
+
+		const session = { actor: user };
+
+		// Create a closed org
+		const org = await ctx.createContract(
+			ctx.adminUserId,
+			ctx.session,
+			'org@1.0.0',
+			'Closed org',
+			{},
+		);
+
+		// Use the user session to try and invite themselves to the org by creating a link
+		await expect(() =>
+			ctx.createLinkThroughWorker(
+				user.id,
+				session,
+				org,
+				user,
+				'has member',
+				'is member of',
+			),
+		).rejects.toThrow(/not a member/);
+	});
+
+	test('should disallow patching a membership link if the user is not a member', async () => {
+		const user = await ctx.createUser(
+			autumndbTestUtils.generateRandomSlug(),
+			undefined,
+			['user-community'],
+		);
+
+		const session = { actor: user };
+
+		// Create a closed org
+		const org = await ctx.createContract(
+			user.id,
+			session,
+			'org@1.0.0',
+			'Closed org',
+			{},
+		);
+
+		// Use the user session to try and invite themselves to the org by creating a link
+		const link = await ctx.createLinkThroughWorker(
+			user.id,
+			session,
+			org,
+			user,
+			'has member',
+			'is member of',
+		);
+
+		const user2 = await ctx.createUser(
+			autumndbTestUtils.generateRandomSlug(),
+			undefined,
+			['user-community'],
+		);
+
+		const session2 = { actor: user2 };
+
+		// Try to patch the link to make user2 a member of the org instead
+		await expect(() =>
+			ctx.worker.patchCard(
+				ctx.logContext,
+				session2,
+				ctx.worker.typeContracts['link@1.0.0'],
+				{
+					actor: user2.id,
+				},
+				link,
+				[
+					{
+						op: 'replace',
+						path: '/data/to/id',
+						value: user2.id,
+					},
+				],
+			),
+		).rejects.toThrow(/not a member/);
+	});
+
+	test('should disallow creating a link to imitate contract creation', async () => {
+		const user = await ctx.createUser(
+			autumndbTestUtils.generateRandomSlug(),
+			undefined,
+			['user-community'],
+		);
+
+		const session = { actor: user };
+
+		// Create a closed org
+		const org = await ctx.createContract(
+			user.id,
+			session,
+			'org@1.0.0',
+			'Closed org',
+			{},
+		);
+
+		const user2 = await ctx.createUser(
+			autumndbTestUtils.generateRandomSlug(),
+			undefined,
+			['user-community'],
+		);
+
+		const session2 = { actor: user2 };
+
+		// Try to trick the system by creating a link to the contract as though user2 was the creator
+		await expect(() =>
+			ctx.createLinkThroughWorker(
+				user2.id,
+				session2,
+				user2,
+				org,
+				'is creator of',
+				'was created by',
+			),
+		).rejects.toThrow(/Cannot create link with reserved name/);
+	});
+});


### PR DESCRIPTION
This change adds a check to see if the user is an org member before allowing link creation between user and org.
This link is used to calculate marker permissions so needs to be specially protected.
It also closes some other holes that would affect the ability to "join" an org.

- Users can no longer create a link between a user and an org if they
are not a member or creator of the org
- When a user creates an org, they automatically become a member of the org
- Users can no longer create "was created by" links manually, as this could be used to bypass org creator validation

Note: This is a temporary solution until we have a better way to handle this. Once we are able to distinctly permission writes in AutumnDB, we can remove this.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>