### PR TITLE
Lock down user contract updates

### DIFF
--- a/test/integration/actions/action-update-card.spec.ts
+++ b/test/integration/actions/action-update-card.spec.ts
@@ -1,0 +1,108 @@
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils, UserContract } from 'autumndb';
+import { ActionContract, testUtils, WorkerContext } from '../../../lib';
+import { actionUpdateCard } from '../../../lib/actions/action-update-card';
+
+let ctx: testUtils.TestContext;
+let actionContext: WorkerContext;
+
+beforeAll(async () => {
+	ctx = await testUtils.newContext();
+	actionContext = ctx.worker.getActionContext(ctx.logContext);
+});
+
+afterAll(async () => {
+	await testUtils.destroyContext(ctx);
+});
+
+describe('action-update-card', () => {
+	test('operators should be able to update other user contracts', async () => {
+		const user = await ctx.createUser(
+			autumndbTestUtils.generateRandomId(),
+			undefined,
+			['user-community', 'user-operator'],
+		);
+		expect(user.data.roles).toEqual(['user-community', 'user-operator']);
+		const otherUser = await ctx.createUser(
+			autumndbTestUtils.generateRandomId(),
+		);
+
+		await actionUpdateCard.handler(
+			{
+				actor: user,
+			},
+			actionContext,
+			otherUser,
+			{
+				action: {} as ActionContract,
+				card: otherUser.id,
+				timestamp: new Date().toISOString(),
+				actor: user.id,
+				logContext: ctx.logContext,
+				epoch: new Date().valueOf(),
+				arguments: {
+					reason: null,
+					patch: [
+						{
+							op: 'replace',
+							path: '/data/email',
+							value: 'foo@bar.com',
+						},
+					],
+				},
+			},
+		);
+		const updated = await ctx.kernel.getContractById<UserContract>(
+			ctx.logContext,
+			{ actor: user },
+			otherUser.id,
+		);
+		assert(updated);
+		expect(updated.data.email).toEqual('foo@bar.com');
+	});
+
+	test('user-admin should be able to update other user contracts', async () => {
+		const adminUser = await ctx.kernel.getContractById<UserContract>(
+			ctx.logContext,
+			ctx.kernel.adminSession()!,
+			ctx.adminUserId,
+		);
+		assert(adminUser);
+		const otherUser = await ctx.createUser(
+			autumndbTestUtils.generateRandomId(),
+		);
+
+		await actionUpdateCard.handler(
+			{
+				actor: adminUser,
+			},
+			actionContext,
+			otherUser,
+			{
+				action: {} as ActionContract,
+				card: otherUser.id,
+				timestamp: new Date().toISOString(),
+				actor: adminUser.id,
+				logContext: ctx.logContext,
+				epoch: new Date().valueOf(),
+				arguments: {
+					reason: null,
+					patch: [
+						{
+							op: 'replace',
+							path: '/data/email',
+							value: 'foo@bar.com',
+						},
+					],
+				},
+			},
+		);
+		const updated = await ctx.kernel.getContractById<UserContract>(
+			ctx.logContext,
+			{ actor: adminUser },
+			otherUser.id,
+		);
+		assert(updated);
+		expect(updated.data.email).toEqual('foo@bar.com');
+	});
+});

--- a/test/integration/contracts/role-user-community.spec.ts
+++ b/test/integration/contracts/role-user-community.spec.ts
@@ -1,17 +1,21 @@
+import { strict as assert } from 'assert';
 import {
 	AutumnDBSession,
 	testUtils as autumndbTestUtils,
 	UserContract,
 } from 'autumndb';
 import _ from 'lodash';
-import { testUtils } from '../../../lib';
+import { ActionContract, testUtils, WorkerContext } from '../../../lib';
+import { actionUpdateCard } from '../../../lib/actions/action-update-card';
 
 let ctx: testUtils.TestContext;
 let user: UserContract;
 let session: AutumnDBSession;
+let actionContext: WorkerContext;
 
 beforeAll(async () => {
 	ctx = await testUtils.newContext();
+	actionContext = ctx.worker.getActionContext(ctx.logContext);
 
 	user = await ctx.createUser(autumndbTestUtils.generateRandomId());
 	session = { actor: user };
@@ -83,5 +87,119 @@ describe('role-user-community', () => {
 			message.id,
 		);
 		expect(result).toBeNull();
+	});
+
+	test('should be able to update own user contract', async () => {
+		const userFoo = await ctx.createUser(autumndbTestUtils.generateRandomId());
+		expect(userFoo.data.roles).toEqual(['user-community']);
+		expect(userFoo.data.email).not.toEqual('foo@bar.com');
+
+		await actionUpdateCard.handler(
+			{
+				actor: userFoo,
+			},
+			actionContext,
+			userFoo,
+			{
+				action: {} as ActionContract,
+				card: userFoo.id,
+				timestamp: new Date().toISOString(),
+				actor: userFoo.id,
+				logContext: ctx.logContext,
+				epoch: new Date().valueOf(),
+				arguments: {
+					reason: null,
+					patch: [
+						{
+							op: 'replace',
+							path: '/data/email',
+							value: 'foo@bar.com',
+						},
+					],
+				},
+			},
+		);
+		const updated = await ctx.kernel.getContractById<UserContract>(
+			ctx.logContext,
+			{ actor: userFoo },
+			userFoo.id,
+		);
+		assert(updated);
+		expect(updated.data.email).toEqual('foo@bar.com');
+	});
+
+	test('should not be able to change own roles', async () => {
+		const userFoo = await ctx.createUser(autumndbTestUtils.generateRandomId());
+		expect(userFoo.data.roles).toEqual(['user-community']);
+		userFoo.data.roles.push('user-operator');
+
+		await actionUpdateCard.handler(
+			{
+				actor: userFoo,
+			},
+			actionContext,
+			userFoo,
+			{
+				action: {} as ActionContract,
+				card: userFoo.id,
+				timestamp: new Date().toISOString(),
+				actor: userFoo.id,
+				logContext: ctx.logContext,
+				epoch: new Date().valueOf(),
+				arguments: {
+					reason: null,
+					patch: [
+						{
+							op: 'replace',
+							path: '/data/roles',
+							value: userFoo.data.roles,
+						},
+					],
+				},
+			},
+		);
+		const updated = await ctx.kernel.getContractById<UserContract>(
+			ctx.logContext,
+			ctx.kernel.adminSession()!,
+			userFoo.id,
+		);
+		assert(updated);
+		expect(updated.data.roles).toEqual(['user-community']);
+	});
+
+	test('should not be able to update other user contracts', async () => {
+		const userFoo = await ctx.createUser(autumndbTestUtils.generateRandomId());
+		expect(userFoo.data.roles).toEqual(['user-community']);
+		const otherUser = await ctx.createUser(
+			autumndbTestUtils.generateRandomId(),
+		);
+
+		await expect(() => {
+			return actionUpdateCard.handler(
+				{
+					actor: userFoo,
+				},
+				actionContext,
+				otherUser,
+				{
+					action: {} as ActionContract,
+					card: otherUser.id,
+					timestamp: new Date().toISOString(),
+					actor: userFoo.id,
+					logContext: ctx.logContext,
+					epoch: new Date().valueOf(),
+					arguments: {
+						reason: null,
+						patch: [
+							{
+								op: 'replace',
+								path: '/data/email',
+								value: 'foo@bar.com',
+							},
+						],
+					},
+				},
+			);
+		}).rejects.toThrow();
 	});
 });


### PR DESCRIPTION
Don't allow normal users to update other user contracts. user-admin
and users with operator role are allowed to edit other user contracts.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

***

Testing with:
- https://github.com/product-os/jellyfish/pull/8916
- https://github.com/product-os/jellyfish-plugin-typeform/pull/979