### PR TITLE
Initialize default contracts before inserting them

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,6 +14,7 @@ import {
 	TypeContract,
 	RelationshipContract,
 	LinkContract,
+	contractMixins,
 } from 'autumndb';
 import * as fastEquals from 'fast-equals';
 import type { Operation } from 'fast-json-patch';
@@ -470,11 +471,13 @@ export class Worker {
 
 		// Get the existing contract and if it is not found or is different, replace it
 		const checkThenReplaceContract = async (
-			contract: Partial<Contract> & { type: string },
+			baseContract: Partial<Contract> & { type: string },
 		) => {
-			if (!contract) {
+			if (!baseContract) {
 				return;
 			}
+			// Add sane defaults to the contract, such as a uiSchema reset
+			const contract = contractMixins.initialize(baseContract as Contract);
 			const current = await this.kernel.getContractBySlug(
 				logContext,
 				this.session,


### PR DESCRIPTION
When loading default contracts into the worker, ensure they are intialized in the same way that contracts loaded from plugins are. This sets the contract up with sane default fields and a uiSchema reset.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>