### PR TITLE
Distribute notification generation on the queue

### DIFF
--- a/lib/actions/action-create-card.ts
+++ b/lib/actions/action-create-card.ts
@@ -40,7 +40,7 @@ const handler: ActionDefinition['handler'] = async (
 	// Validate links if set
 	const linkTargets: LinkTarget[] = [];
 	if (request.arguments.properties.links) {
-		const from = request.arguments.properties.type.split('@')[0];
+		const from = typeContract.slug;
 		const links: Links = request.arguments.properties.links;
 		await Promise.all(
 			(Object.keys(links) as string[]).map(async (name) => {
@@ -77,8 +77,11 @@ const handler: ActionDefinition['handler'] = async (
 
 					// Everything necessary exists, add to link targets
 					linkTargets.push({
-						name: match.name === name ? name : match.data.inverseName!,
-						inverseName: match.data.inverseName === name ? match.name! : name,
+						name: match.name === name ? name : match.data.inverseName,
+						inverseName:
+							match.data.inverseName === name
+								? match.name!
+								: match.data.inverseName,
 						to: {
 							id: target.id,
 							type: target.type,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1680,14 +1680,15 @@ export class Worker {
 					insertedContractType: TypeContract,
 					actorSession: AutumnDBSession,
 					object: any,
+					actor: string,
 				) => {
 					return workerContext.insertCard(
 						actorSession,
 						insertedContractType,
 						{
-							...options,
-							attachEvents: true,
+							actor,
 							timestamp: Date.now(),
+							attachEvents: false,
 						},
 						object,
 					);

--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -195,7 +195,7 @@ export const newContext = async (
 
 	const createEvent = async (
 		actor: string,
-		session: AutumnDBSession,
+		_session: AutumnDBSession,
 		target: Contract,
 		body: string,
 		type: string,
@@ -233,14 +233,14 @@ export const newContext = async (
 		);
 		assert(req);
 
-		await flushAll(session);
+		await flushAll(autumndbTestContext.session);
 		const result: any = await worker.producer.waitResults(
 			autumndbTestContext.logContext,
 			req as ActionRequestContract,
 		);
 		expect(result.error).toBe(false);
 		assert(result.data);
-		await flushAll(session);
+		await flushAll(autumndbTestContext.session);
 		const contract = (await autumndbTestContext.kernel.getContractById(
 			autumndbTestContext.logContext,
 			autumndbTestContext.session,


### PR DESCRIPTION
When generating notifications, distribute the work across the queue

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>