### PR TITLE
Generate notifications when a user is mentioned in a whisper

### DIFF
--- a/lib/subscriptions.ts
+++ b/lib/subscriptions.ts
@@ -152,7 +152,8 @@ export const evaluate = async ({
 	getCreatorSession,
 	query,
 }: EvaluateOptions) => {
-	if (newContract.type === 'message@1.0.0' || newContract.type === 'whisper') {
+	const baseType = newContract.type.split('@')[0];
+	if (baseType === 'message' || baseType === 'whisper') {
 		const oldMentions = oldContract ? getMentions(oldContract) : [];
 		const currentMentions = getMentions(newContract);
 		const newMentions = without(currentMentions, ...oldMentions);


### PR DESCRIPTION
This fixes a bug where the whisper type was not checked correctly, and
a notification would not be generated if there was a mention on a whisper.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>