### PR TITLE
Initialize with a lock

### DIFF
--- a/lib/plugin/plugin-manager.spec.ts
+++ b/lib/plugin/plugin-manager.spec.ts
@@ -240,4 +240,34 @@ describe('PluginManager', () => {
 			});
 		});
 	});
+
+	describe('.getPlugins', () => {
+		test('returns plugins ordered by dependency requirements', () => {
+			const pluginManager = new PluginManager([
+				testPlugin({
+					slug: 'plugin-foo',
+					requires: [{ slug: 'plugin-bar', version: '1.0.0' }],
+				}),
+				testPlugin({ slug: 'plugin-bar' }),
+				testPlugin({
+					slug: 'plugin-buz',
+					requires: [
+						{ slug: 'plugin-bar', version: '1.0.0' },
+						{ slug: 'plugin-foo', version: '1.0.0' },
+						{ slug: 'plugin-baz', version: '1.0.0' },
+					],
+				}),
+				testPlugin({
+					slug: 'plugin-baz',
+					requires: [{ slug: 'plugin-foo', version: '1.0.0' }],
+				}),
+			]);
+			const plugins = pluginManager.getPlugins();
+			expect(plugins.length).toBe(4);
+			expect(plugins[0].slug).toBe('plugin-bar');
+			expect(plugins[1].slug).toBe('plugin-foo');
+			expect(plugins[2].slug).toBe('plugin-baz');
+			expect(plugins[3].slug).toBe('plugin-buz');
+		});
+	});
 });

--- a/lib/plugin/plugin-manager.ts
+++ b/lib/plugin/plugin-manager.ts
@@ -86,4 +86,29 @@ export class PluginManager {
 			_.mapValues(this.pluginMap, (plugin: Plugin) => plugin.getActions()),
 		);
 	}
+
+	/**
+	 * Get all loaded plugins in order of dependency requirements
+	 *
+	 * @returns loaded plugins ordered by dependency needs
+	 */
+	public getPlugins(): Plugin[] {
+		const plugins = Object.values(this.pluginMap);
+		const ordered: Plugin[] = [];
+		while (ordered.length < plugins.length) {
+			for (const plugin of plugins) {
+				if (!ordered.find((p) => p.slug === plugin.slug)) {
+					if (
+						plugin.requires.length === 0 ||
+						plugin.requires.every((required) =>
+							ordered.find((p) => p.slug === required.slug),
+						)
+					) {
+						ordered.push(plugin);
+					}
+				}
+			}
+		}
+		return ordered;
+	}
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@balena/jellyfish-metrics": "^2.0.154",
     "@graphile/logger": "^0.2.0",
     "@types/node": "^17.0.41",
-    "autumndb": "^22.2.25",
+    "autumndb": "22.3.0-joshbwlng-migrations-eccd0c14e4a223a8dc425ad358662bdd6b198a5c",
     "axios": "^0.27.2",
     "bcrypt": "^5.0.1",
     "blueimp-md5": "^2.19.0",


### PR DESCRIPTION
Initialize worker instance using the autumndb migration functionality.
This gives us a system-wide db lock, ensuring that only a single
instance upserts contracts on boot.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

---

Depends on:
- https://github.com/product-os/autumndb/pull/1460