### PR TITLE
Add getElementByMirrorIds enum query function

### DIFF
--- a/lib/sync/instance.ts
+++ b/lib/sync/instance.ts
@@ -237,6 +237,7 @@ export const run = async (
 			getElementBySlug: options.context.getElementBySlug,
 			getElementById: options.context.getElementById,
 			getElementByMirrorId: options.context.getElementByMirrorId,
+			getElementByMirrorIds: options.context.getElementByMirrorIds,
 			request: async (actor: string, requestOptions: HttpRequestOptions) => {
 				assert.INTERNAL(
 					null,

--- a/lib/sync/sync-context.ts
+++ b/lib/sync/sync-context.ts
@@ -353,6 +353,43 @@ export const getActionContext = (
 
 			return elements[0];
 		},
+		getElementByMirrorIds: async (type: string, mirrorIds: string[]) => {
+			strict(mirrorIds.length > 0, 'You must supply at least one mirrorId');
+
+			const elements = await workerContext.query(
+				session,
+				{
+					type: 'object',
+					required: ['type', 'data'],
+					additionalProperties: true,
+					properties: {
+						type: {
+							type: 'string',
+							const: type,
+						},
+						data: {
+							type: 'object',
+							required: ['mirrors'],
+							additionalProperties: true,
+							properties: {
+								mirrors: {
+									type: 'array',
+									contains: {
+										type: 'string',
+										enum: mirrorIds,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					limit: 1,
+				},
+			);
+
+			return elements[0];
+		},
 	};
 
 	return contextObject;

--- a/lib/sync/types.ts
+++ b/lib/sync/types.ts
@@ -87,6 +87,7 @@ export interface IntegrationInitializationOptions {
 		getElementById: SyncActionContext['getElementById'];
 		getContactByEmail: SyncActionContext['getContactByEmail'];
 		getElementByMirrorId: SyncActionContext['getElementByMirrorId'];
+		getElementByMirrorIds: SyncActionContext['getElementByMirrorIds'];
 		request: (
 			actor: string,
 			requestOptions: HttpRequestOptions,

--- a/test/integration/sync-context.spec.ts
+++ b/test/integration/sync-context.spec.ts
@@ -136,6 +136,92 @@ describe('context.getElementByMirrorId()', () => {
 	});
 });
 
+describe('context.getElementByMirrorIds()', () => {
+	test('should match mirrors exactly', async () => {
+		const mirrorId = `test://${uuidv4()}`;
+		const foo = await ctx.createContract(
+			ctx.adminUserId,
+			ctx.worker.session,
+			'card@1.0.0',
+			`contract-${uuidv4()}`,
+			{
+				mirrors: [mirrorId],
+			},
+		);
+		await ctx.createContract(
+			ctx.adminUserId,
+			ctx.worker.session,
+			'card@1.0.0',
+			`contract-${uuidv4()}`,
+			{
+				mirrors: [`test://${uuidv4()}`],
+			},
+		);
+
+		const result: any = await actionContext.getElementByMirrorIds(
+			'card@1.0.0',
+			[mirrorId],
+		);
+		expect(result).toEqual(foo);
+	});
+
+	test('should match by type', async () => {
+		const mirrorId = `test://${uuidv4()}`;
+		const foo = await ctx.createContract(
+			ctx.adminUserId,
+			ctx.worker.session,
+			'card@1.0.0',
+			`contract-${uuidv4()}`,
+			{
+				mirrors: [mirrorId],
+			},
+		);
+		await ctx.createContract(
+			ctx.adminUserId,
+			ctx.worker.session,
+			'org@1.0.0',
+			`card-${uuidv4()}`,
+			{
+				mirrors: [mirrorId],
+			},
+		);
+
+		const result: any = await actionContext.getElementByMirrorIds(
+			'card@1.0.0',
+			[mirrorId],
+		);
+		expect(result).toEqual(foo);
+	});
+
+	test('should not return anything if there is no match', async () => {
+		const mirrorId = `test://${uuidv4()}`;
+		await ctx.createContract(
+			ctx.adminUserId,
+			ctx.worker.session,
+			'card@1.0.0',
+			`contract-${uuidv4()}`,
+			{
+				mirrors: [mirrorId],
+			},
+		);
+		await ctx.createContract(
+			ctx.adminUserId,
+			ctx.worker.session,
+			'card@1.0.0',
+			`contract-${uuidv4()}`,
+			{
+				mirrors: [`test://${uuidv4()}`],
+			},
+		);
+
+		const result: any = await actionContext.getElementByMirrorIds(
+			'card@1.0.0',
+			['foobarbaz'],
+		);
+		expect(result).toBeFalsy();
+	});
+});
+
 describe('context.upsertElement()', () => {
 	test('should create a new element', async () => {
 		const newContract = {


### PR DESCRIPTION
Add a new function for searching for contracts by mirror IDs using
an enum as a more efficient alternative to the pattern search option
provided by getElementByMirrorId.

Change-type: minor
Signed-off-by: Josh Bowling <josh@monarci.com>