### PR TITLE
Make worker use a SyncContext that retries queries that timeout

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,4 +1,5 @@
 import { TypedError } from 'typed-error';
+import { JellyfishError } from './types/index';
 export * from './sync/errors';
 
 export class WorkerAuthenticationError extends TypedError {}
@@ -11,3 +12,7 @@ export class WorkerInvalidVersion extends TypedError {}
 export class WorkerNoElement extends TypedError {}
 export class WorkerNoExecuteEvent extends TypedError {}
 export class WorkerSchemaMismatch extends TypedError {}
+
+export class RetriesExhaustedError extends Error implements JellyfishError {
+	expected: boolean = false;
+}

--- a/lib/sync/index.ts
+++ b/lib/sync/index.ts
@@ -9,6 +9,7 @@ import * as errors from './errors';
 import * as instance from './instance';
 import * as oauth from './oauth';
 import * as pipeline from './pipeline';
+import { retryableContext } from './sync-action-context-retry-wrapper';
 import * as syncContext from './sync-context';
 import type {
 	HttpRequestOptions,
@@ -452,11 +453,8 @@ export class Sync {
 		context: any,
 		session: AutumnDBSession,
 	) {
-		return syncContext.getActionContext(
-			provider,
-			workerContext,
-			context,
-			session,
+		return retryableContext(
+			syncContext.getActionContext(provider, workerContext, context, session),
 		);
 	}
 }

--- a/lib/sync/sync-action-context-retry-wrapper.ts
+++ b/lib/sync/sync-action-context-retry-wrapper.ts
@@ -1,0 +1,123 @@
+import { RetriesExhaustedError } from '../errors';
+import { JellyfishDatabaseTimeoutError, Contract } from 'autumndb';
+import { SyncActionContext } from './sync-context';
+
+/**
+ * Execute `fn`, retrying it if a QueryTimeout error occurs
+ * `fn` must be idempotent
+ *
+ * @param context any
+ * @param fn
+ * @param retries max retries
+ * @returns
+ */
+async function handleQueryTimeout(
+	context: SyncActionContext,
+	fn: any,
+	retries = 100,
+	delay = 2000,
+): Promise<any> {
+	try {
+		return await fn();
+	} catch (error: any) {
+		if (isRetryAllowed(error)) {
+			if (retries > 0) {
+				context.log.warn(
+					`handleQueryTimeout retrying because ${error.message} in ${delay}ms. Retries remaining: ${retries}`,
+					{},
+				);
+
+				await new Promise((resolve) => {
+					setTimeout(resolve, delay);
+				});
+				return await handleQueryTimeout(context, fn, retries - 1, delay);
+			} else {
+				const msg = `handleQueryTimeout retries exhausted! error message ${error.message}`;
+				context.log.error(msg, {
+					error,
+				});
+				throw new RetriesExhaustedError(error);
+			}
+		}
+		throw error;
+	}
+}
+
+function isRetryAllowed(error: Error): boolean {
+	return (
+		(error.name === 'Error' && error.message === 'Query read timeout') ||
+		error instanceof JellyfishDatabaseTimeoutError
+	);
+}
+
+const DEFAULT_OPTIONS = {
+	retries: 5,
+	delay: 2000,
+};
+
+/**
+ * Wraps a worker context, making some operations retry if there's a retryable error
+ * @param context
+ * @param options
+ * @returns
+ */
+export function retryableContext(
+	context: SyncActionContext,
+	options: { retries: number; delay: number } = DEFAULT_OPTIONS,
+) {
+	return {
+		...context,
+		getContactByEmail: (email: string): Promise<Contract | null> => {
+			return handleQueryTimeout(
+				context,
+				async () => context.getContactByEmail(email),
+				options.retries,
+				options.delay,
+			);
+		},
+		getElementBySlug: async (slug: string, usePrivilegedSession = false) => {
+			return handleQueryTimeout(
+				context,
+				async () => context.getElementBySlug(slug, usePrivilegedSession),
+				options.retries,
+				options.delay,
+			);
+		},
+		getElementById: async (id: string) => {
+			return handleQueryTimeout(
+				context,
+				async () => context.getElementById(id),
+				options.retries,
+				options.delay,
+			);
+		},
+		getOauthProviderByIntegration: async (integration: string) => {
+			return handleQueryTimeout(
+				context,
+				async () => context.getOauthProviderByIntegration(integration),
+				options.retries,
+				options.delay,
+			);
+		},
+		getElementByMirrorId: async (
+			type: string,
+			mirrorId: string,
+			getOptions: { usePattern?: boolean } = {},
+		) => {
+			return handleQueryTimeout(
+				context,
+				async () => context.getElementByMirrorId(type, mirrorId, getOptions),
+				options.retries,
+				options.delay,
+			);
+		},
+		getElementByMirrorIds: async (type: string, mirrorIds: string[]) => {
+			return handleQueryTimeout(
+				context,
+				async () => context.getElementByMirrorIds(type, mirrorIds),
+				options.retries,
+				options.delay,
+			);
+		},
+	};
+}

--- a/lib/sync/sync-action-context-retry-wrapper.ts
+++ b/lib/sync/sync-action-context-retry-wrapper.ts
@@ -1,5 +1,5 @@
 import { RetriesExhaustedError } from '../errors';
-import { JellyfishDatabaseTimeoutError, Contract } from 'autumndb';
+import { Contract } from 'autumndb';
 import { SyncActionContext } from './sync-context';
 
 /**
@@ -46,7 +46,7 @@ async function handleQueryTimeout(
 function isRetryAllowed(error: Error): boolean {
 	return (
 		(error.name === 'Error' && error.message === 'Query read timeout') ||
-		error instanceof JellyfishDatabaseTimeoutError
+		error.name === 'JellyfishDatabaseTimeoutError'
 	);
 }
 

--- a/lib/sync/sync-context.ts
+++ b/lib/sync/sync-context.ts
@@ -96,7 +96,7 @@ export const getActionContext = (
 			return map ? map.remote : username;
 		},
 		// The upsertElement function has the property of being eventually
-		// consistent, sanely handling two seperate sync events on a new
+		// consistent, sanely handling two separate sync events on a new
 		// object with the same slug. If an ID is provided we don't need to do any
 		// checking though, as the object already exists and it can be patched
 		// immediately.


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Ramiro Gonzalez <ramiro.gonzalez@balena.io>