### PR TITLE
Stop creating creates/updates for external-events

### DIFF
--- a/lib/actions/action-create-card.ts
+++ b/lib/actions/action-create-card.ts
@@ -92,6 +92,9 @@ const handler: ActionDefinition['handler'] = async (
 		);
 	}
 
+	// Don't attach events for certain types
+	const attachEvents = !['external-event'].includes(typeContract.slug);
+
 	// Create contract
 	const result = await context.insertCard(
 		session,
@@ -101,7 +104,7 @@ const handler: ActionDefinition['handler'] = async (
 			actor: request.actor,
 			originator: request.originator,
 			reason: request.arguments.reason,
-			attachEvents: true,
+			attachEvents,
 		},
 		request.arguments.properties,
 	);

--- a/lib/actions/action-update-card.ts
+++ b/lib/actions/action-update-card.ts
@@ -31,6 +31,9 @@ const handler: ActionDefinition['handler'] = async (
 		);
 	}
 
+	// Don't attach events for certain types
+	const attachEvents = !['external-event'].includes(typeContract.slug);
+
 	const result = await context.patchCard(
 		session,
 		typeContract,
@@ -39,7 +42,7 @@ const handler: ActionDefinition['handler'] = async (
 			reason: request.arguments.reason,
 			actor: request.actor,
 			originator: request.originator,
-			attachEvents: true,
+			attachEvents,
 		},
 		contract,
 		request.arguments.patch,


### PR DESCRIPTION
There is no need to attach create and update contracts to external-event contracts. This only results in the system creating unnecessary extra records in the database.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

---

Testing with:
- https://github.com/product-os/jellyfish-plugin-typeform/pull/1232