### PR TITLE
Schedule action requests with correct session

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2055,7 +2055,7 @@ export class Worker {
 				const actionRequest =
 					await this.kernel.insertContract<ActionRequestContract>(
 						logContext,
-						session,
+						this.session,
 						{
 							slug: utils.getEventSlug('action-request'),
 							type: 'action-request@1.0.0',


### PR DESCRIPTION
Use privileged session to insert action-request contracts for future execution as non-privileged sessions are not allowed to create action-request contracts.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>