### PR TITLE
Make scheduled-actions more flexible

### DIFF
--- a/lib/contracts/scheduled-action.ts
+++ b/lib/contracts/scheduled-action.ts
@@ -17,7 +17,7 @@ export const scheduledAction: ContractDefinition = {
 						options: {
 							title: 'Action request options',
 							type: 'object',
-							required: ['action'],
+							required: ['action', 'arguments'],
 							properties: {
 								action: {
 									type: 'string',

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1815,7 +1815,6 @@ export class Worker {
 		if (
 			scheduledAction &&
 			scheduledAction.active &&
-			scheduledAction.data.options.card &&
 			scheduledAction.data.options.arguments
 		) {
 			const runAt = getNextExecutionDate(scheduledAction.data.schedule);
@@ -1824,9 +1823,9 @@ export class Worker {
 				const data: ActionRequestData = {
 					actor,
 					input: {
-						id: scheduledAction.data.options.card,
+						id: scheduledAction.data.options.card || scheduledAction.id,
 					},
-					card: scheduledAction.data.options.card,
+					card: scheduledAction.data.options.card || scheduledAction.id,
 					action: scheduledAction.data.options.action,
 					context: logContext,
 					epoch,

--- a/lib/types/contracts/scheduled-action.ts
+++ b/lib/types/contracts/scheduled-action.ts
@@ -21,7 +21,7 @@ export interface ActionRequestOptions {
 	action: string;
 	card?: string;
 	type?: string;
-	arguments?: {
+	arguments: {
 		[k: string]: unknown;
 	};
 	context?: {


### PR DESCRIPTION
Update options necessary to run scheduled actions, making them more
flexible so they can be used with more actions.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>